### PR TITLE
Refactor clib and define custom exceptions

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -59,6 +59,28 @@ def check_libgmt(libgmt):
             raise GMTCLibError(msg)
 
 
+def check_status_code(status, function):
+    """
+    Check if the status code returned by a function is non-zero.
+
+    Parameters
+    ----------
+    status : int or None
+        The status code returned by a GMT C API function.
+    function : str
+        The name of the GMT function (used to raise the exception if it's a
+        non-zero status code).
+
+    Raises
+    ------
+    GMTCLibError
+
+    """
+    if status is None or status != 0:
+        raise GMTCLibError(
+            'Failed {} with status code {}.'.format(function, status))
+
+
 def load_libgmt(libname='libgmt'):
     """
     Find and load ``libgmt`` as a ctypes.CDLL.
@@ -159,10 +181,7 @@ def call_module(session, module, args):
 
     mode = get_constant('GMT_MODULE_CMD')
     status = c_call_module(session, module.encode(), mode, args.encode())
-
-    if status is None or status != 0:
-        raise GMTCLibError(
-            'Failed GMT_Call_Module with status code {}.'.format(status))
+    check_status_code(status, 'GMT_Call_Module')
 
 
 def create_session(name='gmt-python-session'):
@@ -227,10 +246,7 @@ def destroy_session(session):
     c_destroy_session.argtypes = [ctypes.c_void_p]
     c_destroy_session.restype = ctypes.c_int
     status = c_destroy_session(session)
-
-    if status is None or status != 0:
-        raise GMTCLibError(
-            'Failed GMT_Destroy_Session with status code {}.'.format(status))
+    check_status_code(status, 'GMT_Destroy_Session')
 
 
 class APISession():  # pylint: disable=too-few-public-methods

--- a/gmt/exceptions.py
+++ b/gmt/exceptions.py
@@ -1,0 +1,31 @@
+"""
+Our custom exceptions
+"""
+
+
+class GMTError(Exception):
+    """
+    Base class for all GMT related errors.
+    """
+    pass
+
+
+class GMTOSError(GMTError):
+    """
+    Unsupported operating system.
+    """
+    pass
+
+
+class GMTCLibNotFoundError(GMTError):
+    """
+    Could not find the GMT shared library.
+    """
+    pass
+
+
+class GMTCLibError(GMTError):
+    """
+    Error encountered when running a function from the GMT shared library.
+    """
+    pass

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -7,6 +7,7 @@ import pytest
 
 from ..clib import create_session, destroy_session, call_module, load_libgmt, \
     APISession, get_constant
+from ..exceptions import GMTCLibError
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -23,7 +24,7 @@ def test_constant():
     assert get_constant('GMT_SESSION_EXTERNAL') != -99999
     assert get_constant('GMT_MODULE_CMD') != -99999
     assert get_constant('GMT_PAD_DEFAULT') != -99999
-    with pytest.raises(ValueError):
+    with pytest.raises(GMTCLibError):
         get_constant('A_WHOLE_LOT_OF_JUNK')
 
 

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -7,7 +7,8 @@ import pytest
 
 from ..clib import create_session, destroy_session, call_module, load_libgmt, \
     APISession, get_constant
-from ..exceptions import GMTCLibError
+from ..clib.core import clib_extension, check_libgmt
+from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -15,8 +16,28 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 def test_load_libgmt():
     "Test that loading libgmt works and doesn't crash."
-    libgmt = load_libgmt()
-    assert hasattr(libgmt, 'GMT_Create_Session')
+    load_libgmt()
+
+
+def test_load_libgmt_fail():
+    "Test that loading fails when given a bad library path."
+    with pytest.raises(GMTCLibNotFoundError):
+        load_libgmt('some/wrong/path/libgmt')
+
+
+def test_check_libgmt():
+    "Make sure check_libgmt fails when given a bogus library"
+    with pytest.raises(GMTCLibError):
+        check_libgmt(dict())
+
+
+def test_clib_extension():
+    "Make sure we get the correct extension for different OS names"
+    for linux in ['linux', 'linux2', 'linux3']:
+        assert clib_extension(linux) == 'so'
+    assert clib_extension('darwin') == 'dylib'
+    with pytest.raises(GMTOSError):
+        clib_extension('meh')
 
 
 def test_constant():
@@ -39,6 +60,12 @@ def test_clib_session_management():
     destroy_session(session2)
 
 
+def test_destroy_session_fails():
+    "Fail to destroy session when given bad input"
+    with pytest.raises(GMTCLibError):
+        destroy_session(None)
+
+
 def test_call_module():
     "Run a psbasemap call to see if the module works"
     data_fname = os.path.join(TEST_DATA_DIR, 'points.txt')
@@ -51,3 +78,12 @@ def test_call_module():
         output = out_file.read().strip().replace('\t', ' ')
         assert output == '11.5309 61.7074 -2.9289 7.8648 0.1412 0.9338'
     os.remove(out_fname)
+
+
+def test_call_module_fails():
+    "Fails when given bad input"
+    with pytest.raises(GMTCLibError):
+        with APISession() as session:
+            call_module(session, 'meh', '')
+    with pytest.raises(GMTCLibError):
+        call_module(None, 'gmtdefaults', '')


### PR DESCRIPTION
Created some exceptions in `gmt/exceptions.py` for use internally.
Replace `assert` with raising these exceptions for better error
handling.