### PR TITLE
Ignore bandit warnings in tests

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: gmt/tests


### PR DESCRIPTION
It complains about the asserts in there and it's kind of annoying