### PR TITLE
Refactor clib funcs to methods of the context manager

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -29,24 +29,22 @@ Utility functions
 Low-level wrappers for the GMT C API
 ------------------------------------
 
-The GMT C API is accessed using ctypes_. The ``gmt.clib`` package offers
-functions and classes that wrap the C API with a pythonic interface.
-
-.. autosummary::
-    :toctree: api/
-    :template: function.rst
-
-    clib.call_module
-    clib.create_session
-    clib.destroy_session
-    clib.load_libgmt
-    clib.get_constant
+The GMT C shared library (``libgmt``)_is accessed using ctypes_.
+The ``gmt.clib`` package offers the :class:`~gmt.clib.LibGMT` class that wraps
+the C shared library with a pythonic interface.
+Most interactions with ``libgmt`` are done through this class.
 
 .. autosummary::
     :toctree: api/
     :template: class.rst
 
-    clib.APISession
+    clib.LibGMT
+
+.. autosummary::
+    :toctree: api/
+    :template: function.rst
+
+    clib.load_libgmt
 
 
 .. _ctypes: https://docs.python.org/3/library/ctypes.html

--- a/gmt/base_plotting.py
+++ b/gmt/base_plotting.py
@@ -2,7 +2,7 @@
 Base class with plot generating commands.
 Does not define any special non-GMT methods (savefig, show, etc).
 """
-from .clib import call_module, APISession
+from .clib import LibGMT
 from .utils import build_arg_string
 from .decorators import fmt_docstring, use_alias, kwargs_to_strings
 
@@ -97,8 +97,8 @@ class BasePlotting():
 
         """
         kwargs = self._preprocess(**kwargs)
-        with APISession() as session:
-            call_module(session, 'pscoast', build_arg_string(kwargs))
+        with LibGMT() as lib:
+            lib.call_module('pscoast', build_arg_string(kwargs))
 
     @fmt_docstring
     @use_alias(R='region', J='projection', B='frame', P='portrait', S='style',
@@ -157,8 +157,8 @@ class BasePlotting():
         kwargs = self._preprocess(**kwargs)
         assert isinstance(data, str), 'Only accepts file names for now.'
         arg_str = ' '.join([data, build_arg_string(kwargs)])
-        with APISession() as session:
-            call_module(session, 'psxy', arg_str)
+        with LibGMT() as lib:
+            lib.call_module('psxy', arg_str)
 
     @fmt_docstring
     @use_alias(R='region', J='projection', B='frame', P='portrait')
@@ -208,5 +208,5 @@ class BasePlotting():
         if 'D' in kwargs:
             assert 'F' in kwargs, \
                 "Option D requires F to be specified as well."
-        with APISession() as session:
-            call_module(session, 'psbasemap', build_arg_string(kwargs))
+        with LibGMT() as lib:
+            lib.call_module('psbasemap', build_arg_string(kwargs))

--- a/gmt/clib/__init__.py
+++ b/gmt/clib/__init__.py
@@ -1,5 +1,4 @@
 """
 Low-level wrappers for the GMT C API using ctypes
 """
-from .core import load_libgmt, create_session, destroy_session, call_module, \
-    APISession, get_constant
+from .core import load_libgmt, LibGMT

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -114,142 +114,7 @@ def load_libgmt(libname='libgmt'):
     return libgmt
 
 
-def get_constant(name):
-    """
-    Get the value of a constant (C enum) from gmt_resources.h
-
-    Used to set configuration values for other API calls.
-
-    Parameters
-    ----------
-    name : str
-        The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
-
-    Returns
-    -------
-    constant : int
-        Integer value of the constant. Do not rely on this value because it
-        might change.
-
-    Raises
-    ------
-    ValueError
-        If the constant doesn't exist.
-
-    """
-    libgmt = load_libgmt()
-    c_get_enum = libgmt.GMT_Get_Enum
-    c_get_enum.argtypes = [ctypes.c_char_p]
-    c_get_enum.restype = ctypes.c_int
-
-    value = c_get_enum(name.encode())
-
-    assert value is not None, 'GMT_Get_Enum failed returning None.'
-    if value == -99999:
-        raise GMTCLibError(
-            "Constant '{}' doesn't exits in libgmt.".format(name))
-
-    return value
-
-
-def call_module(session, module, args):
-    """
-    Call a GMT module with the given arguments.
-
-    Makes a call to ``GMT_Call_Module`` from the C API using mode
-    ``GMT_MODULE_CMD`` (arguments passed as a single string).
-
-    Most interactions with the C API are done through this function.
-
-    Parameters
-    ----------
-    session : ctypes.c_void_p
-        A ctypes void pointer to a GMT session created by
-        :func:`gmt.clib.APISession`.
-    module : str
-        Module name (``'pscoast'``, ``'psbasemap'``, etc).
-    args : str
-        String with the command line arguments that will be passed to the
-        module (for example, ``'-R0/5/0/10 -JM'``).
-
-    """
-    libgmt = load_libgmt()
-    c_call_module = libgmt.GMT_Call_Module
-    c_call_module.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int,
-                              ctypes.c_void_p]
-    c_call_module.restype = ctypes.c_int
-
-    mode = get_constant('GMT_MODULE_CMD')
-    status = c_call_module(session, module.encode(), mode, args.encode())
-    check_status_code(status, 'GMT_Call_Module')
-
-
-def create_session(name='gmt-python-session'):
-    """
-    Create the ``GMTAPI_CTRL`` struct required by the GMT C API functions.
-
-    .. warning::
-
-        Best not used directly. Use :class:`gmt.clib.APISession` instead.
-
-    It is a C void pointer containing the current session information and
-    cannot be accessed directly.
-
-    Remember to terminate the current session using
-    :func:`gmt.clib.destroy_session` before creating a new one.
-
-    Returns
-    -------
-    api_pointer : C void pointer (returned by ctypes as an integer)
-        Used by GMT C API functions.
-
-    """
-    libgmt = load_libgmt()
-    c_create_session = libgmt.GMT_Create_Session
-    c_create_session.argtypes = [ctypes.c_char_p, ctypes.c_uint, ctypes.c_uint,
-                                 ctypes.c_void_p]
-    c_create_session.restype = ctypes.c_void_p
-    # None is passed in place of the print function pointer. It becomes the
-    # NULL pointer when passed to C, prompting the C API to use the default
-    # print function.
-    session = c_create_session(name.encode(),
-                               get_constant('GMT_PAD_DEFAULT'),
-                               get_constant('GMT_SESSION_EXTERNAL'),
-                               None)
-
-    if session is None:
-        raise GMTCLibError("Failed to create a GMT API void pointer.")
-
-    return session
-
-
-def destroy_session(session):
-    """
-    Terminate and free the memory of a registered ``GMTAPI_CTRL`` session.
-
-    .. warning::
-
-        Best not used directly. Use :class:`gmt.clib.APISession` instead.
-
-    The session is created and consumed by the C API modules and needs to be
-    freed before creating a new. Otherwise, some of the configuration files
-    might be left behind and can influence subsequent API calls.
-
-    Parameters
-    ----------
-    session : C void pointer (returned by ctypes as an integer)
-        The active session object produced by :func:`gmt.clib.create_session`.
-
-    """
-    libgmt = load_libgmt()
-    c_destroy_session = libgmt.GMT_Destroy_Session
-    c_destroy_session.argtypes = [ctypes.c_void_p]
-    c_destroy_session.restype = ctypes.c_int
-    status = c_destroy_session(session)
-    check_status_code(status, 'GMT_Destroy_Session')
-
-
-class APISession():  # pylint: disable=too-few-public-methods
+class LibGMT():
     """
     Context manager to create a GMT C API session and destroy it.
 
@@ -261,24 +126,152 @@ class APISession():  # pylint: disable=too-few-public-methods
     Examples
     --------
 
-    >>> with APISession() as session:
-    ...     call_module(session, 'figure', 'my-figure')
+    >>> with LibGMT() as gmt:
+    ...     gmt.call_module('figure', 'my-figure')
 
     """
 
     def __init__(self):
-        self.session_id = None
+        self._libgmt = load_libgmt()
+        self._session_id = None
+        self._session_name = 'gmt-python-session'
 
     def __enter__(self):
         """
         Start the GMT session and keep the session argument.
         """
-        self.session_id = create_session()
-        return self.session_id
+        self._session_id = self._create_session()
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         """
         Destroy the session when exiting the context.
         """
-        destroy_session(self.session_id)
-        self.session_id = None
+        self._destroy_session(self._session_id)
+        self._session_id = None
+
+    def _create_session(self):
+        """
+        Create the ``GMTAPI_CTRL`` struct required by the GMT C API functions.
+
+        .. warning::
+
+            Best not used directly. Use :class:`gmt.clib.APISession` instead.
+
+        It is a C void pointer containing the current session information and
+        cannot be accessed directly.
+
+        Remember to terminate the current session using
+        :func:`gmt.clib.destroy_session` before creating a new one.
+
+        Returns
+        -------
+        api_pointer : C void pointer (returned by ctypes as an integer)
+            Used by GMT C API functions.
+
+        """
+        c_create_session = self._libgmt.GMT_Create_Session
+        c_create_session.argtypes = [ctypes.c_char_p, ctypes.c_uint,
+                                     ctypes.c_uint, ctypes.c_void_p]
+        c_create_session.restype = ctypes.c_void_p
+        # None is passed in place of the print function pointer. It becomes the
+        # NULL pointer when passed to C, prompting the C API to use the default
+        # print function.
+        session = c_create_session(self._session_name.encode(),
+                                   self.get_constant('GMT_PAD_DEFAULT'),
+                                   self.get_constant('GMT_SESSION_EXTERNAL'),
+                                   None)
+
+        if session is None:
+            raise GMTCLibError("Failed to create a GMT API void pointer.")
+
+        return session
+
+    def _destroy_session(self, session):
+        """
+        Terminate and free the memory of a registered ``GMTAPI_CTRL`` session.
+
+        .. warning::
+
+            Best not used directly. Use :class:`gmt.clib.APISession` instead.
+
+        The session is created and consumed by the C API modules and needs to
+        be freed before creating a new. Otherwise, some of the configuration
+        files might be left behind and can influence subsequent API calls.
+
+        Parameters
+        ----------
+        session : C void pointer (returned by ctypes as an integer)
+            The active session object produced by
+            :func:`gmt.clib.create_session`.
+
+        """
+        c_destroy_session = self._libgmt.GMT_Destroy_Session
+        c_destroy_session.argtypes = [ctypes.c_void_p]
+        c_destroy_session.restype = ctypes.c_int
+
+        status = c_destroy_session(session)
+        check_status_code(status, 'GMT_Destroy_Session')
+
+    def get_constant(self, name):
+        """
+        Get the value of a constant (C enum) from gmt_resources.h
+
+        Used to set configuration values for other API calls.
+
+        Parameters
+        ----------
+        name : str
+            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
+
+        Returns
+        -------
+        constant : int
+            Integer value of the constant. Do not rely on this value because it
+            might change.
+
+        Raises
+        ------
+        ValueError
+            If the constant doesn't exist.
+
+        """
+        c_get_enum = self._libgmt.GMT_Get_Enum
+        c_get_enum.argtypes = [ctypes.c_char_p]
+        c_get_enum.restype = ctypes.c_int
+
+        value = c_get_enum(name.encode())
+
+        if value is None or value == -99999:
+            raise GMTCLibError(
+                "Constant '{}' doesn't exits in libgmt.".format(name))
+
+        return value
+
+    def call_module(self, module, args):
+        """
+        Call a GMT module with the given arguments.
+
+        Makes a call to ``GMT_Call_Module`` from the C API using mode
+        ``GMT_MODULE_CMD`` (arguments passed as a single string).
+
+        Most interactions with the C API are done through this function.
+
+        Parameters
+        ----------
+        module : str
+            Module name (``'pscoast'``, ``'psbasemap'``, etc).
+        args : str
+            String with the command line arguments that will be passed to the
+            module (for example, ``'-R0/5/0/10 -JM'``).
+
+        """
+        c_call_module = self._libgmt.GMT_Call_Module
+        c_call_module.argtypes = [ctypes.c_void_p, ctypes.c_char_p,
+                                  ctypes.c_int, ctypes.c_void_p]
+        c_call_module.restype = ctypes.c_int
+
+        mode = self.get_constant('GMT_MODULE_CMD')
+        status = c_call_module(self._session_id, module.encode(), mode,
+                               args.encode())
+        check_status_code(status, 'GMT_Call_Module')

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     Image = None
 
-from .clib import call_module, APISession
+from .clib import LibGMT
 from .base_plotting import BasePlotting
 from .utils import build_arg_string
 from .decorators import fmt_docstring, use_alias, kwargs_to_strings
@@ -40,8 +40,8 @@ def figure(name):
     """
     # Passing format '-' tells gmt.end to not produce any files.
     fmt = '-'
-    with APISession() as session:
-        call_module(session, 'figure', '{} {}'.format(name, fmt))
+    with LibGMT() as lib:
+        lib.call_module('figure', '{} {}'.format(name, fmt))
 
 
 def unique_name():
@@ -185,8 +185,8 @@ class Figure(BasePlotting):
         # Default portrait mode to True
         if 'P' not in kwargs:
             kwargs['P'] = ''
-        with APISession() as session:
-            call_module(session, 'psconvert', build_arg_string(kwargs))
+        with LibGMT() as lib:
+            lib.call_module('psconvert', build_arg_string(kwargs))
 
     def savefig(self, fname, orientation='portrait', transparent=False,
                 crop=True, **kwargs):

--- a/gmt/session_management.py
+++ b/gmt/session_management.py
@@ -1,7 +1,7 @@
 """
 Modern mode session management modules.
 """
-from .clib import call_module, APISession
+from .clib import LibGMT
 
 
 def begin():
@@ -14,8 +14,8 @@ def begin():
 
     """
     prefix = 'gmt-python-session'
-    with APISession() as session:
-        call_module(session, 'begin', prefix)
+    with LibGMT() as lib:
+        lib.call_module('begin', prefix)
 
 
 def end():
@@ -28,5 +28,5 @@ def end():
     ``gmt.begin``), and bring the figures to the working directory.
 
     """
-    with APISession() as session:
-        call_module(session, 'end', '')
+    with LibGMT() as lib:
+        lib.call_module('end', '')

--- a/gmt/tests/test_session_management.py
+++ b/gmt/tests/test_session_management.py
@@ -4,7 +4,7 @@ Test the session management modules.
 import os
 
 from ..session_management import begin, end
-from ..clib import APISession, call_module
+from ..clib import LibGMT
 
 
 def test_begin_end():
@@ -14,8 +14,8 @@ def test_begin_end():
     """
     end()  # Kill the global session
     begin()
-    with APISession() as session:
-        call_module(session, 'psbasemap', '-R10/70/-3/8 -JX4i/3i -Ba -P')
+    with LibGMT() as lib:
+        lib.call_module('psbasemap', '-R10/70/-3/8 -JX4i/3i -Ba -P')
     end()
     begin()  # Restart the global session
     assert os.path.exists('gmt-python-session.pdf')


### PR DESCRIPTION
The functions in `gmt.clib` need to keep be passed the session pointer and users have to remember to get it from `APISession`, which just handles creating and deleting the pointer. For example:

    with APISession() as session:
        call_module(session, ...)

Turn the functions into methods of the context manager and rename it `LibGMT`. 
Hide away the session management functions as private methods.
So now it looks like:

    with LibGMT() as lib:
        lib.call_module(...)

Fixes #38 