### PR TITLE
Lowlevel wrapper for GMT_Create_Data

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -153,13 +153,24 @@ class LibGMT():
 
     """
 
-    _valid_families = ['GMT_IS_DATASET',
-                       'GMT_IS_GRID',
-                       'GMT_IS_PALETTE',
-                       'GMT_IS_TEXTSET',
-                       'GMT_IS_MATRIX',
-                       'GMT_IS_VECTOR']
+    _valid_data_families = [
+        'GMT_IS_DATASET',
+        'GMT_IS_GRID',
+        'GMT_IS_PALETTE',
+        'GMT_IS_TEXTSET',
+        'GMT_IS_MATRIX',
+        'GMT_IS_VECTOR',
+    ]
     _valid_vias = ['GMT_VIA_MATRIX', 'GMT_VIA_VECTOR']
+    _valid_data_geometries = [
+        'GMT_IS_NONE',
+        'GMT_IS_POINT',
+        'GMT_IS_LINE',
+        'GMT_IS_POLYGON',
+        'GMT_IS_PLP',
+        'GMT_IS_SURFACE',
+    ]
+    _valid_data_modes = ['GMT_CONTAINER_ONLY', 'GMT_OUTPUT']
 
     def __init__(self):
         self._libgmt = load_libgmt()
@@ -307,15 +318,19 @@ class LibGMT():
         """
         Create an empty GMT data container.
 
-        Optionally allocate memory for the data (depending on the given
-        *mode*).
-
         Parameters
         ----------
         family : str
 
         """
-        pass
+        family_int = self._parse_data_family(family)
+        if geometry not in self._valid_data_geometries:
+            raise GMTCLibError("Invalid data geometry '{}'.".format(geometry))
+        if mode not in self._valid_data_modes:
+            raise GMTCLibError("Invalid data creation mode '{}'.".format(mode))
+        # TODO: Check if dim, range and int are giving correctly
+        # TODO: Pass things to libgmt
+
 
     def _parse_data_family(self, family):
         """
@@ -349,7 +364,7 @@ class LibGMT():
             raise GMTCLibError(
                 "Too many sections in family (>2): '{}'".format(family))
         family_name = parts[0]
-        if family_name not in self._valid_families:
+        if family_name not in self._valid_data_families:
             raise GMTCLibError(
                 "Invalid data family '{}'.".format(family_name))
         family_value = self.get_constant(family_name)

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -325,8 +325,12 @@ class LibGMT():
         """
         # Parse and check input arguments
         family_int = self._parse_data_family(family)
-        geometry_int = self._parse_data_geometry(geometry)
-        mode_int = self._parse_data_mode(mode)
+        if mode not in self._valid_data_modes:
+            raise GMTCLibError("Invalid data creation mode '{}'.".format(mode))
+        mode_int = self.get_constant(mode)
+        if geometry not in self._valid_data_geometries:
+            raise GMTCLibError("Invalid data geometry '{}'.".format(geometry))
+        geometry_int = self.get_constant(geometry)
         registration = kwargs.get('registration',
                                   self.get_constant('GMT_GRID_NODE_REG'))
         pad = kwargs.get('pad', self.get_constant('GMT_PAD_DEFAULT'))
@@ -362,36 +366,14 @@ class LibGMT():
         """
         """
         # Check if dim, range and int are giving correctly
-        if 'dim' in kwargs:
-            int_array_4 = ctypes.c_uint64*4
-            dim = int_array_4(*kwargs['dim'])
-        else:
-            dim = None
-        if 'range' in kwargs:
-            double_array_4 = ctypes.c_double*4
-            ranges = double_array_4(*kwargs['range'])
-        else:
-            ranges = None
-        if 'inc' in kwargs:
-            double_array_2 = ctypes.c_double*2
-            inc = double_array_2(*kwargs['inc'])
-        else:
-            inc = None
-        return dim, ranges, inc
-
-    def _parse_data_mode(self, mode):
-        """
-        """
-        if mode not in self._valid_data_modes:
-            raise GMTCLibError("Invalid data creation mode '{}'.".format(mode))
-        return self.get_constant(mode)
-
-    def _parse_data_geometry(self, geometry):
-        """
-        """
-        if geometry not in self._valid_data_geometries:
-            raise GMTCLibError("Invalid data geometry '{}'.".format(geometry))
-        return self.get_constant(geometry)
+        formats = dict(dim=ctypes.c_uint64*4,
+                       range=ctypes.c_double*4,
+                       inc=ctypes.c_double*2)
+        args = [None]*3
+        for i, arg in enumerate(['dim', 'range', 'inc']):
+            if arg in kwargs:
+                args[i] = formats[arg](*kwargs[arg])
+        return args
 
     def _parse_data_family(self, family):
         """

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -294,3 +294,70 @@ class LibGMT():
         status = c_call_module(self._session_id, module.encode(), mode,
                                args.encode())
         check_status_code(status, 'GMT_Call_Module')
+
+    def create_data(self, family, geometry, mode, **kwargs):
+        """
+        Create an empty GMT data container.
+
+        Optionally allocate memory for the data (depending on the given
+        *mode*).
+
+        Parameters
+        ----------
+        family : str
+
+        """
+        pass
+
+    def _parse_data_family(self, family):
+        """
+        Parse the data family string into a GMT constant number.
+
+        Valid family names are: GMT_IS_DATASET, GMT_IS_GRID, GMT_IS_PALETTE,
+        GMT_IS_TEXTSET, GMT_IS_MATRIX, and GMT_IS_VECTOR.
+
+        Optionally append a "via" argument to a family name (separated by
+        ``|``): GMT_VIA_MATRIX or GMT_VIA_VECTOR.
+
+        Parameters
+        ----------
+        family : str
+            A GMT data family name.
+
+        Returns
+        -------
+        family_value : int
+            The GMT constant corresponding to the family.
+
+        Raises
+        ------
+        GMTCLibError
+            If the family name is invalid or there are more than 2 components
+            to the name.
+
+        """
+        valid_families = ['GMT_IS_DATASET',
+                          'GMT_IS_GRID',
+                          'GMT_IS_PALETTE',
+                          'GMT_IS_TEXTSET',
+                          'GMT_IS_MATRIX',
+                          'GMT_IS_VECTOR']
+        valid_via = ['GMT_VIA_MATRIX', 'GMT_VIA_VECTOR']
+        parts = family.split('|')
+        if len(parts) > 2:
+            raise GMTCLibError(
+                "Too many sections in family (>2): '{}'".format(family))
+        family_name = parts[0]
+        if family_name not in valid_families:
+            raise GMTCLibError(
+                "Invalid data family '{}'.".format(family_name))
+        family_value = self.get_constant(family_name)
+        if len(parts) == 2:
+            via_name = parts[1]
+            if via_name not in valid_via:
+                raise GMTCLibError(
+                    "Invalid data family (via) '{}'.".format(via_name))
+            via_value = self.get_constant(via_name)
+        else:
+            via_value = 0
+        return family_value + via_value

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -153,6 +153,14 @@ class LibGMT():
 
     """
 
+    _valid_families = ['GMT_IS_DATASET',
+                       'GMT_IS_GRID',
+                       'GMT_IS_PALETTE',
+                       'GMT_IS_TEXTSET',
+                       'GMT_IS_MATRIX',
+                       'GMT_IS_VECTOR']
+    _valid_vias = ['GMT_VIA_MATRIX', 'GMT_VIA_VECTOR']
+
     def __init__(self):
         self._libgmt = load_libgmt()
         self._session_id = None
@@ -336,25 +344,18 @@ class LibGMT():
             to the name.
 
         """
-        valid_families = ['GMT_IS_DATASET',
-                          'GMT_IS_GRID',
-                          'GMT_IS_PALETTE',
-                          'GMT_IS_TEXTSET',
-                          'GMT_IS_MATRIX',
-                          'GMT_IS_VECTOR']
-        valid_via = ['GMT_VIA_MATRIX', 'GMT_VIA_VECTOR']
         parts = family.split('|')
         if len(parts) > 2:
             raise GMTCLibError(
                 "Too many sections in family (>2): '{}'".format(family))
         family_name = parts[0]
-        if family_name not in valid_families:
+        if family_name not in self._valid_families:
             raise GMTCLibError(
                 "Invalid data family '{}'.".format(family_name))
         family_value = self.get_constant(family_name)
         if len(parts) == 2:
             via_name = parts[1]
-            if via_name not in valid_via:
+            if via_name not in self._valid_vias:
                 raise GMTCLibError(
                     "Invalid data family (via) '{}'.".format(via_name))
             via_value = self.get_constant(via_name)

--- a/gmt/clib/io.py
+++ b/gmt/clib/io.py
@@ -48,11 +48,27 @@ def create_data(libgmt, session, family, geometry, mode, **kwargs):
         raise GMTCLibError("Invalid data creation mode '{}'.".format(mode))
     if geometry not in DATA_GEOMETRIES:
         raise GMTCLibError("Invalid data geometry '{}'.".format(geometry))
+
+    # Convert dim, ranges, and inc to ctypes arrays if given
+    if 'dim' in kwargs:
+        dim_type = ctypes.c_uint64*4
+        dim = dim_type(*kwargs['dim'])
+    else:
+        dim = None
+
+
+    formats = dict(,
+                   ranges=ctypes.c_double*4,
+                   inc=ctypes.c_double*2)
+
+    dim, ranges, inc = _dim_range_inc_to_ctypes(kwargs)
+
+    # Use the GMT defaults if no value is given
     registration = kwargs.get('registration',
                               get_constant('GMT_GRID_NODE_REG', libgmt))
     pad = kwargs.get('pad', get_constant('GMT_PAD_DEFAULT', libgmt))
 
-    dim, ranges, inc = _dim_range_inc_to_ctypes(kwargs)
+
 
     # Get the C function and set the argument types
     c_create_data = libgmt.GMT_Create_Data
@@ -87,6 +103,9 @@ def create_data(libgmt, session, family, geometry, mode, **kwargs):
         raise GMTCLibError("Failed to create an empty GMT data pointer.")
 
     return data_ptr
+
+
+def _kwarg_to_ctypes(name, kwargs, dtype):
 
 
 def _dim_range_inc_to_ctypes(kwargs):

--- a/gmt/clib/io.py
+++ b/gmt/clib/io.py
@@ -39,7 +39,47 @@ def create_data(libgmt, session, family, geometry, mode, **kwargs):
 
     Parameters
     ----------
+    libgmt : ctypes.CDLL
+        The ``ctypes.CDLL`` instance for the libgmt shared library.
+    session : C void pointer (returned by ctypes as an integer)
+        The active session object produced by
+        :func:`gmt.clib.core.create_session`.
     family : str
+        A valid GMT data family name (e.g., ``'GMT_IS_DATASET'``). See the
+        ``DATA_FAMILIES`` variable for valid names.
+    geometry : str
+        A valid GMT data geometry name (e.g., ``'GMT_IS_POINT'``). See the
+        ``DATA_GEOMETRIES`` variable for valid names.
+    mode : str
+        A valid GMT data mode (e.g., ``'GMT_OUTPUT'``). See the ``DATA_MODES``
+        variable for valid names.
+    dim : list of 4 integers
+        The dimensions of the dataset. See the documentation for the GMT C API
+        function ``GMT_Create_Data`` (``src/gmt_api.c``) for the full range of
+        options regarding 'dim'. If ``None``, will pass in the NULL pointer.
+    ranges : list of 4 floats
+        The dataset extent. Also a bit of a complicated argument. See the C
+        function documentation. It's called ``range`` in the C function but it
+        would conflict with the Python built-in ``range`` function.
+    inc : list of 2 floats
+        The increments between points of the dataset. See the C function
+        documentation.
+    registration : int
+        The node registration (what the coordinates mean). Also a very complex
+        argument. See the C function documentation. Defaults to
+        ``GMT_GRID_NODE_REG``.
+    pad : int
+        The grid padding. Defaults to ``GMT_PAD_DEFAULT``.
+
+    Returns
+    -------
+    data_ptr : int
+        A ctypes pointer (an integer) to the allocated ``GMT_Dataset`` object.
+
+    Raises
+    ------
+    GMTCLibError
+        In case of invalid inputs or data_ptr being NULL.
 
     """
     # Parse and check input arguments

--- a/gmt/clib/io.py
+++ b/gmt/clib/io.py
@@ -97,7 +97,7 @@ def _dim_range_inc_to_ctypes(kwargs):
                    ranges=ctypes.c_double*4,
                    inc=ctypes.c_double*2)
     args = [None]*3
-    for i, arg in enumerate(formats.keys()):
+    for i, arg in enumerate(['dim', 'ranges', 'inc']):
         if arg in kwargs:
             args[i] = formats[arg](*kwargs[arg])
     return args

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -106,6 +106,10 @@ class Figure(BasePlotting):
     def __init__(self):
         self._name = unique_name()
         self._preview_dir = TemporaryDirectory(prefix=self._name + '-preview-')
+        # Needed to fool matplotlib.pyplot.close into thinking this is a
+        # matplotlib figure. The close function is called by pytest-mpl with
+        # the figure as an argument.
+        self.int = 0
 
     def __del__(self):
         # Clean up the temporary directory that stores the previews

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -96,15 +96,19 @@ def test_call_module_no_session():
         lib.call_module('gmtdefaults', '')
 
 
-def test_parse_data_family():
-    "Parsing the family argument correctly."
-    # 'family' can be a single GMT constant or two separated by a |
+def test_parse_data_family_single():
+    "Parsing a single family argument correctly."
     with LibGMT() as lib:
-        families = lib._valid_families
-        vias = lib._valid_vias
-        test_cases = ((family, via) for family in families for via in vias)
-        for family in families:
+        for family in lib._valid_families:
             assert lib._parse_data_family(family) == lib.get_constant(family)
+
+
+def test_parse_data_family_via():
+    "Parsing a composite family argument (separated by |) correctly."
+    with LibGMT() as lib:
+        test_cases = ((family, via)
+                      for family in lib._valid_families
+                      for via in lib._valid_vias)
         for family, via in test_cases:
             composite = '|'.join([family, via])
             expected = lib.get_constant(family) + lib.get_constant(via)

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -162,14 +162,15 @@ def test_create_data_grid_dim():
         )
 
 
-# def test_create_data_grid_range():
-    # "Run the function to make sure it doesn't fail badly."
-    # with LibGMT() as lib:
-        # # Grids from matrices using range and int
-        # data_grid = lib.create_data(
-            # family='GMT_IS_GRID|GMT_VIA_MATRIX',
-            # geometry='GMT_IS_SURFACE',
-            # mode='GMT_CONTAINER_ONLY',
-            # range=[150, 250, -20, 20],  # WESN
-            # inc=[0.1, 0.2],  # dlon, dlat
-        # )
+def test_create_data_grid_range():
+    "Run the function to make sure it doesn't fail badly."
+    with LibGMT() as lib:
+        # Grids from matrices using range and int
+        lib.create_data(
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='GMT_IS_SURFACE',
+            mode='GMT_CONTAINER_ONLY',
+            dim=[0, 0, 1, 0],
+            range=[150., 250., -20., 20.],
+            inc=[0.1, 0.2],
+        )

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -99,32 +99,28 @@ def test_call_module_no_session():
 def test_parse_data_family():
     "Parsing the family argument correctly."
     # 'family' can be a single GMT constant or two separated by a |
-    families = ['GMT_IS_DATASET',
-                'GMT_IS_GRID',
-                'GMT_IS_PALETTE',
-                'GMT_IS_TEXTSET',
-                'GMT_IS_MATRIX',
-                'GMT_IS_VECTOR']
-    vias = ['GMT_VIA_MATRIX', 'GMT_VIA_VECTOR']
     with LibGMT() as lib:
+        families = lib._valid_families
+        vias = lib._valid_vias
+        test_cases = ((family, via) for family in families for via in vias)
         for family in families:
             assert lib._parse_data_family(family) == lib.get_constant(family)
-            for via in vias:
-                composite = '|'.join([family, via])
-                expected = lib.get_constant(family) + lib.get_constant(via)
-                assert lib._parse_data_family(composite) == expected
+        for family, via in test_cases:
+            composite = '|'.join([family, via])
+            expected = lib.get_constant(family) + lib.get_constant(via)
+            assert lib._parse_data_family(composite) == expected
+
 
 def test_parse_data_family_fails():
     "Check if the function fails when given bad input"
     with LibGMT() as lib:
-        with pytest.raises(GMTCLibError):
-            lib._parse_data_family('SOME_random_STRING')
-        with pytest.raises(GMTCLibError):
-            lib._parse_data_family(
-                'GMT_IS_DATASET|GMT_VIA_MATRIX|GMT_VIA_VECTOR')
-        with pytest.raises(GMTCLibError):
-            lib._parse_data_family('GMT_IS_DATASET|NOT_A_PROPER_VIA')
-        with pytest.raises(GMTCLibError):
-            lib._parse_data_family('NOT_A_PROPER_FAMILY|GMT_VIA_MATRIX')
-        with pytest.raises(GMTCLibError):
-            lib._parse_data_family('NOT_A_PROPER_FAMILY|ALSO_INVALID')
+        test_cases = [
+            'SOME_random_STRING',
+            'GMT_IS_DATASET|GMT_VIA_MATRIX|GMT_VIA_VECTOR',
+            'GMT_IS_DATASET|NOT_A_PROPER_VIA',
+            'NOT_A_PROPER_FAMILY|GMT_VIA_MATRIX',
+            'NOT_A_PROPER_FAMILY|ALSO_INVALID',
+        ]
+        for test_case in test_cases:
+            with pytest.raises(GMTCLibError):
+                lib._parse_data_family(test_case)

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -99,7 +99,7 @@ def test_call_module_no_session():
 def test_parse_data_family_single():
     "Parsing a single family argument correctly."
     with LibGMT() as lib:
-        for family in lib._valid_families:
+        for family in lib._valid_data_families:
             assert lib._parse_data_family(family) == lib.get_constant(family)
 
 
@@ -107,7 +107,7 @@ def test_parse_data_family_via():
     "Parsing a composite family argument (separated by |) correctly."
     with LibGMT() as lib:
         test_cases = ((family, via)
-                      for family in lib._valid_families
+                      for family in lib._valid_data_families
                       for via in lib._valid_vias)
         for family, via in test_cases:
             composite = '|'.join([family, via])
@@ -128,3 +128,46 @@ def test_parse_data_family_fails():
         for test_case in test_cases:
             with pytest.raises(GMTCLibError):
                 lib._parse_data_family(test_case)
+
+
+def test_create_data():
+    "Run the function to make sure it doesn't fail badly."
+    with LibGMT() as lib:
+        data_pointers = []
+        # Dataset from vectors
+        data_vector = lib.create_data(
+            family='GMT_IS_DATASET|GMT_VIA_VECTOR',
+            geometry='GMT_IS_POINT',
+            mode='GMT_CONTAINER_ONLY',
+            dim=[10, 20, 1, 0],  # columns, rows, layers, dtype
+        )
+        # Dataset from matrices
+        data_matrix = lib.create_data(
+            family='GMT_IS_DATASET|GMT_VIA_MATRIX',
+            geometry='GMT_IS_POINT',
+            mode='GMT_CONTAINER_ONLY',
+            dim=[10, 20, 1, 0],
+        )
+        # Grids from matrices using dim
+        data_grid_dim = lib.create_data(
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='GMT_IS_SURFACE',
+            mode='GMT_CONTAINER_ONLY',
+            dim=[10, 20, 1, 0],
+        )
+        # Grids from matrices using range and int
+        data_grid = lib.create_data(
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='GMT_IS_SURFACE',
+            mode='GMT_CONTAINER_ONLY',
+            range=[150, 250, -20, 20],  # WESN
+            int=[0.1, 0.2],  # dlon, dlat
+        )
+        # Grids from matrices using range and int
+        data_grid = lib.create_data(
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='GMT_IS_SURFACE',
+            mode='GMT_CONTAINER_ONLY',
+            range=[150, 250, -20, 20],  # WESN
+            int=[0.1, 0.2],  # dlon, dlat
+        )

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -130,10 +130,9 @@ def test_parse_data_family_fails():
                 lib._parse_data_family(test_case)
 
 
-def test_create_data():
+def test_create_data_dataset():
     "Run the function to make sure it doesn't fail badly."
     with LibGMT() as lib:
-        data_pointers = []
         # Dataset from vectors
         data_vector = lib.create_data(
             family='GMT_IS_DATASET|GMT_VIA_VECTOR',
@@ -148,26 +147,29 @@ def test_create_data():
             mode='GMT_CONTAINER_ONLY',
             dim=[10, 20, 1, 0],
         )
+        assert data_vector != data_matrix
+
+
+def test_create_data_grid_dim():
+    "Run the function to make sure it doesn't fail badly."
+    with LibGMT() as lib:
         # Grids from matrices using dim
-        data_grid_dim = lib.create_data(
+        lib.create_data(
             family='GMT_IS_GRID|GMT_VIA_MATRIX',
             geometry='GMT_IS_SURFACE',
             mode='GMT_CONTAINER_ONLY',
             dim=[10, 20, 1, 0],
         )
-        # Grids from matrices using range and int
-        data_grid = lib.create_data(
-            family='GMT_IS_GRID|GMT_VIA_MATRIX',
-            geometry='GMT_IS_SURFACE',
-            mode='GMT_CONTAINER_ONLY',
-            range=[150, 250, -20, 20],  # WESN
-            int=[0.1, 0.2],  # dlon, dlat
-        )
-        # Grids from matrices using range and int
-        data_grid = lib.create_data(
-            family='GMT_IS_GRID|GMT_VIA_MATRIX',
-            geometry='GMT_IS_SURFACE',
-            mode='GMT_CONTAINER_ONLY',
-            range=[150, 250, -20, 20],  # WESN
-            int=[0.1, 0.2],  # dlon, dlat
-        )
+
+
+# def test_create_data_grid_range():
+    # "Run the function to make sure it doesn't fail badly."
+    # with LibGMT() as lib:
+        # # Grids from matrices using range and int
+        # data_grid = lib.create_data(
+            # family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            # geometry='GMT_IS_SURFACE',
+            # mode='GMT_CONTAINER_ONLY',
+            # range=[150, 250, -20, 20],  # WESN
+            # inc=[0.1, 0.2],  # dlon, dlat
+        # )

--- a/gmt/tests/test_clib_io.py
+++ b/gmt/tests/test_clib_io.py
@@ -113,7 +113,7 @@ def test_create_data_fails():
         create_data(
             libgmt=lib,
             session=session,
-            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            family='GMT_IS_DATASET',
             geometry='GMT_IS_SURFACE',
             mode='Not_a_valid_mode',
             dim=[0, 0, 1, 0],
@@ -125,7 +125,7 @@ def test_create_data_fails():
         create_data(
             libgmt=lib,
             session=session,
-            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            family='GMT_IS_GRID',
             geometry='Not_a_valid_geometry',
             mode='GMT_CONTAINER_ONLY',
             dim=[0, 0, 1, 0],

--- a/gmt/tests/test_clib_io.py
+++ b/gmt/tests/test_clib_io.py
@@ -102,3 +102,34 @@ def test_create_data_grid_range():
         inc=[0.1, 0.2],
     )
     destroy_session(session, lib)
+
+
+def test_create_data_fails():
+    "Test for failures on bad input"
+    lib = load_libgmt()
+    session = create_session('test_create_data', lib)
+    # Passing in invalid mode
+    with pytest.raises(GMTCLibError):
+        create_data(
+            libgmt=lib,
+            session=session,
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='GMT_IS_SURFACE',
+            mode='Not_a_valid_mode',
+            dim=[0, 0, 1, 0],
+            ranges=[150., 250., -20., 20.],
+            inc=[0.1, 0.2],
+        )
+    # Passing in invalid geometry
+    with pytest.raises(GMTCLibError):
+        create_data(
+            libgmt=lib,
+            session=session,
+            family='GMT_IS_GRID|GMT_VIA_MATRIX',
+            geometry='Not_a_valid_geometry',
+            mode='GMT_CONTAINER_ONLY',
+            dim=[0, 0, 1, 0],
+            ranges=[150., 250., -20., 20.],
+            inc=[0.1, 0.2],
+        )
+    destroy_session(session, lib)


### PR DESCRIPTION
Implement a low-level hook to `GMT_Create_Data` (used to create a GMT dataset that can be populated with numpy array data).

Introduces the new module `gmt/clib/io.py`. The function is not accessible from the public API (i.e., `LibGMT`). They will be serve as a basis for a high-level virtual file API.

Lays the foundation for #22 