### PR TITLE
C lib access through funcs called by LibGMT

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -29,7 +29,7 @@ Utility functions
 Low-level wrappers for the GMT C API
 ------------------------------------
 
-The GMT C shared library (``libgmt``)_is accessed using ctypes_.
+The GMT C shared library (``libgmt``) is accessed using ctypes_.
 The ``gmt.clib`` package offers the :class:`~gmt.clib.LibGMT` class that wraps
 the C shared library with a pythonic interface.
 Most interactions with ``libgmt`` are done through this class.
@@ -39,12 +39,6 @@ Most interactions with ``libgmt`` are done through this class.
     :template: class.rst
 
     clib.LibGMT
-
-.. autosummary::
-    :toctree: api/
-    :template: function.rst
-
-    clib.load_libgmt
 
 
 .. _ctypes: https://docs.python.org/3/library/ctypes.html

--- a/gmt/clib/__init__.py
+++ b/gmt/clib/__init__.py
@@ -1,4 +1,4 @@
 """
 Low-level wrappers for the GMT C API using ctypes
 """
-from .core import load_libgmt, LibGMT
+from .context_manager import LibGMT

--- a/gmt/clib/context_manager.py
+++ b/gmt/clib/context_manager.py
@@ -1,0 +1,97 @@
+"""
+Defines the LibGMT context manager that is the main interface with libgmt.
+"""
+from .core import load_libgmt, create_session, destroy_session, call_module, \
+    get_constant
+
+
+class LibGMT():
+    """
+    Load and access the GMT shared library (libgmt).
+
+    Works as a context manager to create a GMT C API session and destroy it in
+    the end.
+
+    Functions of the shared library are exposed as methods of this class.
+
+    If creating GMT data structures to communicate data, put that code inside
+    this context manager and reuse the same session.
+
+    Examples
+    --------
+
+    >>> with LibGMT() as lib:
+    ...     lib.call_module('figure', 'my-figure')
+
+    """
+
+    def __init__(self):
+        self._libgmt = load_libgmt()
+        self._session_id = None
+        self._session_name = 'gmt-python-session'
+
+    def __enter__(self):
+        """
+        Start the GMT session and keep the session argument.
+        """
+        self._session_id = create_session(self._session_name, self._libgmt)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Destroy the session when exiting the context.
+        """
+        destroy_session(self._session_id, self._libgmt)
+        self._session_id = None
+
+    def get_constant(self, name):
+        """
+        Get the value of a constant (C enum) from gmt_resources.h
+
+        Used to set configuration values for other API calls. Wraps
+        ``GMT_Get_Enum``.
+
+        Parameters
+        ----------
+        name : str
+            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
+
+        Returns
+        -------
+        constant : int
+            Integer value of the constant. Do not rely on this value because it
+            might change.
+
+        Raises
+        ------
+        GMTCLibError
+            If the constant doesn't exist.
+
+        """
+        value = get_constant(name, self._libgmt)
+        return value
+
+    def call_module(self, module, args):
+        """
+        Call a GMT module with the given arguments.
+
+        Makes a call to ``GMT_Call_Module`` from the C API using mode
+        ``GMT_MODULE_CMD`` (arguments passed as a single string).
+
+        Most interactions with the C API are done through this function.
+
+        Parameters
+        ----------
+        module : str
+            Module name (``'pscoast'``, ``'psbasemap'``, etc).
+        args : str
+            String with the command line arguments that will be passed to the
+            module (for example, ``'-R0/5/0/10 -JM'``).
+
+        Raises
+        ------
+        GMTCLibError
+            If the returned status code of the functions is non-zero.
+
+        """
+        call_module(self._session_id, module, args, self._libgmt)

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -1,43 +1,10 @@
 """
 ctypes wrappers for core functions from the C API
 """
-import sys
 import ctypes
 
-from ..exceptions import GMTOSError, GMTCLibNotFoundError, GMTCLibError
-
-
-def clib_extension(os_name=None):
-    """
-    Return the extension for the shared library for the current OS.
-
-    .. warning::
-
-        Currently only works for OSX and Linux.
-
-    Returns
-    -------
-    os_name : str or None
-        The operating system name as given by ``sys.platform``
-        (the default if None).
-
-    Returns
-    -------
-    ext : str
-        The extension ('.so', '.dylib', etc).
-
-    """
-    if os_name is None:
-        os_name = sys.platform
-    # Set the shared library extension in a platform independent way
-    if os_name.startswith('linux'):
-        lib_ext = 'so'
-    elif os_name == 'darwin':
-        # Darwin is OSX
-        lib_ext = 'dylib'
-    else:
-        raise GMTOSError('Unknown operating system: {}'.format(sys.platform))
-    return lib_ext
+from ..exceptions import GMTCLibNotFoundError, GMTCLibError
+from .utils import clib_extension, check_status_code
 
 
 def check_libgmt(libgmt):
@@ -69,29 +36,6 @@ def check_libgmt(libgmt):
                 "Couldn't access function GMT_{}.".format(func),
             ])
             raise GMTCLibError(msg)
-
-
-def check_status_code(status, function):
-    """
-    Check if the status code returned by a function is non-zero.
-
-    Parameters
-    ----------
-    status : int or None
-        The status code returned by a GMT C API function.
-    function : str
-        The name of the GMT function (used to raise the exception if it's a
-        non-zero status code).
-
-    Raises
-    ------
-    GMTCLibError
-        If the status code is non-zero.
-
-    """
-    if status is None or status != 0:
-        raise GMTCLibError(
-            'Failed {} with status code {}.'.format(function, status))
 
 
 def load_libgmt(libname='libgmt'):
@@ -133,164 +77,146 @@ def load_libgmt(libname='libgmt'):
     return libgmt
 
 
-class LibGMT():
+def create_session(session_name, libgmt):
     """
-    Load and access the GMT shared library (libgmt).
+    Create the ``GMTAPI_CTRL`` struct required by the GMT C API functions.
 
-    Works as a context manager to create a GMT C API session and destroy it in
-    the end.
+    It is a C void pointer containing the current session information and
+    cannot be accessed directly.
 
-    Functions of the shared library are exposed as methods of this class.
+    Remember to terminate the current session using
+    :func:`gmt.clib.LibGMT._destroy_session` before creating a new one.
 
-    If creating GMT data structures to communicate data, put that code inside
-    this context manager and reuse the same session.
+    Parameters
+    ----------
+    session_name : str
+        A name for this session. Doesn't really affect the outcome.
+    libgmt : ctypes.CDLL
+        The ``ctypes.CDLL`` instance for the libgmt shared library.
 
-    Examples
-    --------
-
-    >>> with LibGMT() as lib:
-    ...     lib.call_module('figure', 'my-figure')
+    Returns
+    -------
+    api_pointer : C void pointer (returned by ctypes as an integer)
+        Used by GMT C API functions.
 
     """
+    c_create_session = libgmt.GMT_Create_Session
+    c_create_session.argtypes = [ctypes.c_char_p, ctypes.c_uint,
+                                 ctypes.c_uint, ctypes.c_void_p]
+    c_create_session.restype = ctypes.c_void_p
+    # None is passed in place of the print function pointer. It becomes the
+    # NULL pointer when passed to C, prompting the C API to use the default
+    # print function.
+    print_func = None
+    padding = get_constant('GMT_PAD_DEFAULT', libgmt)
+    session_type = get_constant('GMT_SESSION_EXTERNAL', libgmt)
+    session = c_create_session(session_name.encode(), padding, session_type,
+                               print_func)
 
-    def __init__(self):
-        self._libgmt = load_libgmt()
-        self._session_id = None
-        self._session_name = 'gmt-python-session'
+    if session is None:
+        raise GMTCLibError("Failed to create a GMT API void pointer.")
 
-    def __enter__(self):
-        """
-        Start the GMT session and keep the session argument.
-        """
-        self._session_id = self._create_session()
-        return self
+    return session
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        """
-        Destroy the session when exiting the context.
-        """
-        self._destroy_session(self._session_id)
-        self._session_id = None
 
-    def _create_session(self):
-        """
-        Create the ``GMTAPI_CTRL`` struct required by the GMT C API functions.
+def destroy_session(session, libgmt):
+    """
+    Terminate and free the memory of a registered ``GMTAPI_CTRL`` session.
 
-        It is a C void pointer containing the current session information and
-        cannot be accessed directly.
+    The session is created and consumed by the C API modules and needs to
+    be freed before creating a new. Otherwise, some of the configuration
+    files might be left behind and can influence subsequent API calls.
 
-        Remember to terminate the current session using
-        :func:`gmt.clib.LibGMT._destroy_session` before creating a new one.
+    Parameters
+    ----------
+    session : C void pointer (returned by ctypes as an integer)
+        The active session object produced by
+        :func:`gmt.clib.core.create_session`.
+    libgmt : ctypes.CDLL
+        The ``ctypes.CDLL`` instance for the libgmt shared library.
 
-        Returns
-        -------
-        api_pointer : C void pointer (returned by ctypes as an integer)
-            Used by GMT C API functions.
+    """
+    c_destroy_session = libgmt.GMT_Destroy_Session
+    c_destroy_session.argtypes = [ctypes.c_void_p]
+    c_destroy_session.restype = ctypes.c_int
 
-        """
-        c_create_session = self._libgmt.GMT_Create_Session
-        c_create_session.argtypes = [ctypes.c_char_p, ctypes.c_uint,
-                                     ctypes.c_uint, ctypes.c_void_p]
-        c_create_session.restype = ctypes.c_void_p
-        # None is passed in place of the print function pointer. It becomes the
-        # NULL pointer when passed to C, prompting the C API to use the default
-        # print function.
-        session = c_create_session(self._session_name.encode(),
-                                   self.get_constant('GMT_PAD_DEFAULT'),
-                                   self.get_constant('GMT_SESSION_EXTERNAL'),
-                                   None)
+    status = c_destroy_session(session)
+    check_status_code(status, 'GMT_Destroy_Session')
 
-        if session is None:
-            raise GMTCLibError("Failed to create a GMT API void pointer.")
 
-        return session
+def get_constant(name, libgmt):
+    """
+    Get the value of a constant (C enum) from gmt_resources.h
 
-    def _destroy_session(self, session):
-        """
-        Terminate and free the memory of a registered ``GMTAPI_CTRL`` session.
+    Used to set configuration values for other API calls. Wraps
+    ``GMT_Get_Enum``.
 
-        The session is created and consumed by the C API modules and needs to
-        be freed before creating a new. Otherwise, some of the configuration
-        files might be left behind and can influence subsequent API calls.
+    Parameters
+    ----------
+    name : str
+        The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
+    libgmt : ctypes.CDLL
+        The ``ctypes.CDLL`` instance for the libgmt shared library.
 
-        Parameters
-        ----------
-        session : C void pointer (returned by ctypes as an integer)
-            The active session object produced by
-            :func:`gmt.clib.LibGMT._create_session`.
+    Returns
+    -------
+    constant : int
+        Integer value of the constant. Do not rely on this value because it
+        might change.
 
-        """
-        c_destroy_session = self._libgmt.GMT_Destroy_Session
-        c_destroy_session.argtypes = [ctypes.c_void_p]
-        c_destroy_session.restype = ctypes.c_int
+    Raises
+    ------
+    GMTCLibError
+        If the constant doesn't exist.
 
-        status = c_destroy_session(session)
-        check_status_code(status, 'GMT_Destroy_Session')
+    """
+    c_get_enum = libgmt.GMT_Get_Enum
+    c_get_enum.argtypes = [ctypes.c_char_p]
+    c_get_enum.restype = ctypes.c_int
 
-    def get_constant(self, name):
-        """
-        Get the value of a constant (C enum) from gmt_resources.h
+    value = c_get_enum(name.encode())
 
-        Used to set configuration values for other API calls.
+    if value is None or value == -99999:
+        raise GMTCLibError(
+            "Constant '{}' doesn't exits in libgmt.".format(name))
 
-        Parameters
-        ----------
-        name : str
-            The name of the constant (e.g., ``"GMT_SESSION_EXTERNAL"``)
+    return value
 
-        Returns
-        -------
-        constant : int
-            Integer value of the constant. Do not rely on this value because it
-            might change.
 
-        Raises
-        ------
-        GMTCLibError
-            If the constant doesn't exist.
+def call_module(session, module, args, libgmt):
+    """
+    Call a GMT module with the given arguments.
 
-        """
-        c_get_enum = self._libgmt.GMT_Get_Enum
-        c_get_enum.argtypes = [ctypes.c_char_p]
-        c_get_enum.restype = ctypes.c_int
+    Makes a call to ``GMT_Call_Module`` from the C API using mode
+    ``GMT_MODULE_CMD`` (arguments passed as a single string).
 
-        value = c_get_enum(name.encode())
+    Most interactions with the C API are done through this function.
 
-        if value is None or value == -99999:
-            raise GMTCLibError(
-                "Constant '{}' doesn't exits in libgmt.".format(name))
+    Parameters
+    ----------
+    session : C void pointer (returned by ctypes as an integer)
+        The active session object produced by
+        :func:`gmt.clib.core.create_session`.
+    module : str
+        Module name (``'pscoast'``, ``'psbasemap'``, etc).
+    args : str
+        String with the command line arguments that will be passed to the
+        module (for example, ``'-R0/5/0/10 -JM'``).
+    libgmt : ctypes.CDLL
+        The ``ctypes.CDLL`` instance for the libgmt shared library.
 
-        return value
+    Raises
+    ------
+    GMTCLibError
+        If the returned status code of the functions is non-zero.
 
-    def call_module(self, module, args):
-        """
-        Call a GMT module with the given arguments.
+    """
+    c_call_module = libgmt.GMT_Call_Module
+    c_call_module.argtypes = [ctypes.c_void_p, ctypes.c_char_p,
+                              ctypes.c_int, ctypes.c_void_p]
+    c_call_module.restype = ctypes.c_int
 
-        Makes a call to ``GMT_Call_Module`` from the C API using mode
-        ``GMT_MODULE_CMD`` (arguments passed as a single string).
-
-        Most interactions with the C API are done through this function.
-
-        Parameters
-        ----------
-        module : str
-            Module name (``'pscoast'``, ``'psbasemap'``, etc).
-        args : str
-            String with the command line arguments that will be passed to the
-            module (for example, ``'-R0/5/0/10 -JM'``).
-
-        Raises
-        ------
-        GMTCLibError
-            If the returned status code of the functions is non-zero.
-
-        """
-        c_call_module = self._libgmt.GMT_Call_Module
-        c_call_module.argtypes = [ctypes.c_void_p, ctypes.c_char_p,
-                                  ctypes.c_int, ctypes.c_void_p]
-        c_call_module.restype = ctypes.c_int
-
-        mode = self.get_constant('GMT_MODULE_CMD')
-        status = c_call_module(self._session_id, module.encode(), mode,
-                               args.encode())
-        check_status_code(status, 'GMT_Call_Module')
+    mode = get_constant('GMT_MODULE_CMD', libgmt)
+    status = c_call_module(session, module.encode(), mode,
+                           args.encode())
+    check_status_code(status, 'GMT_Call_Module')

--- a/gmt/clib/utils.py
+++ b/gmt/clib/utils.py
@@ -1,0 +1,62 @@
+"""
+Miscellaneous utilities
+"""
+import sys
+
+from ..exceptions import GMTOSError, GMTCLibError
+
+
+def clib_extension(os_name=None):
+    """
+    Return the extension for the shared library for the current OS.
+
+    .. warning::
+
+        Currently only works for OSX and Linux.
+
+    Returns
+    -------
+    os_name : str or None
+        The operating system name as given by ``sys.platform``
+        (the default if None).
+
+    Returns
+    -------
+    ext : str
+        The extension ('.so', '.dylib', etc).
+
+    """
+    if os_name is None:
+        os_name = sys.platform
+    # Set the shared library extension in a platform independent way
+    if os_name.startswith('linux'):
+        lib_ext = 'so'
+    elif os_name == 'darwin':
+        # Darwin is OSX
+        lib_ext = 'dylib'
+    else:
+        raise GMTOSError('Unknown operating system: {}'.format(sys.platform))
+    return lib_ext
+
+
+def check_status_code(status, function):
+    """
+    Check if the status code returned by a function is non-zero.
+
+    Parameters
+    ----------
+    status : int or None
+        The status code returned by a GMT C API function.
+    function : str
+        The name of the GMT function (used to raise the exception if it's a
+        non-zero status code).
+
+    Raises
+    ------
+    GMTCLibError
+        If the status code is non-zero.
+
+    """
+    if status is None or status != 0:
+        raise GMTCLibError(
+            'Failed {} with status code {}.'.format(function, status))


### PR DESCRIPTION
The class LibGMT will start getting big with the wrappers for creating
and accessing data. Move the actual wrapper code to functions in
gmt.clib.core (like it was before) and have LibGMT methods call these
functions (passing in the loaded library and session). This will allow
us to separate the functions into files if we need it without breaking
the class.