### PR TITLE
Remove mentions of GMT_TEXTSET

### DIFF
--- a/gmt/clib/io.py
+++ b/gmt/clib/io.py
@@ -11,7 +11,6 @@ DATA_FAMILIES = [
     'GMT_IS_DATASET',
     'GMT_IS_GRID',
     'GMT_IS_PALETTE',
-    'GMT_IS_TEXTSET',
     'GMT_IS_MATRIX',
     'GMT_IS_VECTOR',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ tag_prefix = ''
 [flake8]
 exclude =
     gmt/_version.py
-ignore = F401,E226,I101,I100
+ignore = F401,E226,I101,I100,E741
 
 [pep8]
-ignore = F401,E226,I101,I100
+ignore = F401,E226,I101,I100,E741


### PR DESCRIPTION
This data type is no longer present in GMT.

Added an exception to the PEP8 checker that was catching the 1-letter
GMT argument I.