### PR TITLE
Skip the slow OSX tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ matrix:
               - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
-        - os: osx
-          env:
-              - PYTHON=3.5
-        - os: osx
-          env:
-              - PYTHON=3.6
-              - COVERAGE=true
-              - BUILD_DOCS=true
+        #- os: osx
+          #env:
+              #- PYTHON=3.5
+        #- os: osx
+          #env:
+              #- PYTHON=3.6
+              #- COVERAGE=true
+              #- BUILD_DOCS=true
 
 before_install:
     # Get Miniconda from Continuum


### PR DESCRIPTION
They take sometimes hours to start and have been failing randomly.
Comment them out of the build matrix and enable later when it's time for
a release.