### PR TITLE
Don't rely on error code of GMT commands

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -393,11 +393,9 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
                 msg = "Invalid GMT module name '{}'.".format(module)
             else:
                 msg = '\n'.join([
-                    "'{}' failed (error: {}).".format(module, status),
+                    "Command '{}' failed:".format(module),
                     "---------- Error log ----------",
-                    '',
                     log,
-                    '',
                     "-------------------------------",
                 ])
             raise GMTCLibError(msg)

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -122,11 +122,9 @@ def test_call_module_error_message():
     "Check that the exception has the error message from call_module"
     data_file = 'bogus-data.bla'
     true_msg = '\n'.join([
-        "'info' failed (error: 69).",
+        "Command 'info' failed:",
         "---------- Error log ----------",
-        '',
         'gmtinfo [ERROR]: Error for input file: No such file (bogus-data.bla)',
-        '',
         "-------------------------------",
     ])
     with LibGMT() as lib:


### PR DESCRIPTION
Don't print them out on the error log or rely on them for testing. These
things might change between GMT versions and break tests.