### PR TITLE
Include pytest in install instructions

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -47,3 +47,8 @@ h1 {
 .rst-content .highlight > pre {
     font-size: 14px;
 }
+
+.rst-content img {
+    max-width: 450px;
+    width: 100%;
+}

--- a/doc/first-steps.ipynb
+++ b/doc/first-steps.ipynb
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We add elements to the figure using its methods. For example, lets add the coastlines of Central America to a 6 inch wide map using the Mercator projection (`M`). Our figure will also have a nice frame with automatic tics."
+    "We add elements to the figure using its methods. For example, lets add the coastlines of Central America to a 6 inch wide map using the Mercator projection (`M`). Our figure will also have a nice frame with automatic ticks."
    ]
   },
   {

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -61,7 +61,7 @@ environment and won't affect your default installation.
 
 Install the latest version of GMT 6::
 
-    conda install gmt -c conda-forge/label/dev
+    conda install gmt -c conda-forge/label/dev -c conda-forge
 
 And finally, install the rest of the dependencies::
 
@@ -93,9 +93,19 @@ Alternatively, you can clone the git repository and install using ``pip``::
     cd gmt-python
     pip install .
 
-This will allow you to use the GMT/Python library.
-Test your installation by running the following inside a Python interpreter
-(be sure to have your conda env activated)::
+This will allow you to use the ``gmt`` library from Python.
+
+
+Testing your install
+--------------------
+
+GMT/Python ships with a full test suite.
+You can run our tests after you install it but you will need a few extra
+dependencies as well (be sure to have your conda env activated)::
+
+    conda install pytest pytest-mpl -c conda-forge
+
+Test your installation by running the following inside a Python interpreter::
 
     import gmt
     gmt.test()


### PR DESCRIPTION
Mention that you need pytest and to run the tests and include a conda
install command.
Include '-c conda-forge' for GMT install to make sure all dependencies
come from the right place.
Fix a typo in the first steps notebook.

Fixes #84 