### PR TITLE
Put the API reference for modules in a single page

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 # Internal variables.
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-.PHONY: help clean html linkcheck doctest
+.PHONY: help clean html linkcheck doctest api
 
 all: html
 
@@ -30,14 +30,20 @@ clean:
 	rm -rf .ipynb_checkpoints
 	rm -rf tutorials/first-steps-*
 
-html:
+html: api
 	@echo
 	@echo "Building HTML files."
 	@echo
-	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+api:
+	@echo
+	@echo "Building API docs."
+	@echo
+	$(SPHINXAUTOGEN) -i -t _templates -o api/ api/_generate_api.rst
+
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -30,6 +30,10 @@ h1 {
     font-size: 4em;
 }
 
+.api-module {
+	margin-bottom: 80px;
+}
+
 .youtube-embed {
     max-width: 600px;
     margin-bottom: 24px;

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -11,7 +11,8 @@
 
     <hr>
 
-.. rubric:: Methods Documentation
+Methods Documentation
+---------------------
 
 {% for item in methods %}
 {% if item != '__init__' %}

--- a/doc/_templates/autosummary/module.rst
+++ b/doc/_templates/autosummary/module.rst
@@ -1,5 +1,9 @@
 The ``{{ fullname }}`` module
-{% for i in range(fullname|length + 15) %}={% endfor %}
+{% for i in range(fullname|length + 15) %}-{% endfor %}
+
+.. raw:: html
+
+    <hr>
 
 .. automodule:: {{ fullname }}
 

--- a/doc/api/_generate_api.rst
+++ b/doc/api/_generate_api.rst
@@ -1,0 +1,16 @@
+Generate the API reference
+==========================
+
+This page is not included in the documentation. It's used to generate the stub
+pages for the modules below. The stubs are then included in api/index.rst so
+that the entire reference is in a single page instead of in separate pages.
+
+To include a new package/module, list it below and include it in api.index.rst
+
+.. autosummary::
+   :toctree: ./
+
+   gmt
+   gmt.clib
+   gmt.exceptions
+

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -3,9 +3,26 @@
 API Reference
 =============
 
-.. autosummary::
-   :toctree: generated/
+.. raw:: html
 
-   gmt
-   gmt.clib
-   gmt.exceptions
+    <div class="api-module">
+
+.. include:: gmt.rst
+
+.. raw:: html
+
+    </div>
+    <div class="api-module">
+
+.. include:: gmt.clib.rst
+
+.. raw:: html
+
+    </div>
+    <div class="api-module">
+
+.. include:: gmt.exceptions.rst
+
+.. raw:: html
+
+    </div>


### PR DESCRIPTION
Instead of having the API for gmt, gmt.clib etc in separate pages, put
them all in the same one.
sphinx autosummary doesn't support this directly so I'm generating the
module references in a dummy page and then including them in api/index.