### PR TITLE
Convert list kwargs to multiple arg string entries

### DIFF
--- a/gmt/utils.py
+++ b/gmt/utils.py
@@ -124,9 +124,10 @@ def build_arg_string(kwargs):
 
     >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i", P='', E=200)))
     -E200 -JX4i -P -R1/2/3/4
-    >>> print(build_arg_string(dict(B=['xaf', 'yaf', 'WSen'],
-    ...                             I=['1/1p,blue', '2/0.25p,blue'])))
-    -Bxaf -Byaf -BWSen -I1/1p,blue -I2/0.25p,blue
+    >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i",
+    ...                             B=['xaf', 'yaf', 'WSen'],
+    ...                             I=('1/1p,blue', '2/0.25p,blue'))))
+    -Bxaf -Byaf -BWSen -I1/1p,blue -I2/0.25p,blue -JX4i -R1/2/3/4
 
     """
     sorted_args = []

--- a/gmt/utils.py
+++ b/gmt/utils.py
@@ -124,12 +124,19 @@ def build_arg_string(kwargs):
 
     >>> print(build_arg_string(dict(R='1/2/3/4', J="X4i", P='', E=200)))
     -E200 -JX4i -P -R1/2/3/4
+    >>> print(build_arg_string(dict(B=['xaf', 'yaf', 'WSen'],
+    ...                             I=['1/1p,blue', '2/0.25p,blue'])))
+    -Bxaf -Byaf -BWSen -I1/1p,blue -I2/0.25p,blue
 
     """
-    sorted_args = (
-        '-{}{}'.format(key, kwargs[key])
-        for key in sorted(kwargs)
-    )
+    sorted_args = []
+    for key in sorted(kwargs):
+        if is_nonstr_iter(kwargs[key]):
+            for value in kwargs[key]:
+                sorted_args.append('-{}{}'.format(key, value))
+        else:
+            sorted_args.append('-{}{}'.format(key, kwargs[key]))
+
     arg_str = ' '.join(sorted_args)
     return arg_str
 


### PR DESCRIPTION
Fixes #21 

Implemented in `build_arg_string` instead of `kwargs_to_strings` because we can't have multiple entries in a dictionary with the same key.
  