### PR TITLE
Raise an informative exception if IPython is not available

### DIFF
--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -297,7 +297,7 @@ class Figure(BasePlotting):
             Only if ``external=False``.
 
         """
-        if external or Image is None:
+        if external:
             pdf = self._preview(fmt='pdf', dpi=600, anti_alias=False,
                                 as_bytes=False)
             launch_external_viewer(pdf)

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -297,7 +297,7 @@ class Figure(BasePlotting):
             Only if ``external=False``.
 
         """
-        if external:
+        if external or Image is None:
             pdf = self._preview(fmt='pdf', dpi=600, anti_alias=False,
                                 as_bytes=False)
             launch_external_viewer(pdf)

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -17,6 +17,7 @@ from .clib import LibGMT
 from .base_plotting import BasePlotting
 from .utils import build_arg_string
 from .decorators import fmt_docstring, use_alias, kwargs_to_strings
+from .exceptions import GMTError
 
 
 def figure(name):
@@ -305,6 +306,11 @@ class Figure(BasePlotting):
         else:
             png = self._preview(fmt='png', dpi=dpi, anti_alias=True,
                                 as_bytes=True)
+            if Image is None:
+                raise GMTError(' '.join([
+                    "Cannot find IPython.",
+                    "Make sure you have it installed",
+                    "or use 'external=True' to open in an external viewer."]))
             img = Image(data=png, width=width)
         return img
 


### PR DESCRIPTION
Fix #108.

When IPython is not installed, `gmt.Figure().show()` will report an error. In this case, it's better to open the figure in an external window even without the option `external=True`.