### PR TITLE
GMTTempfile context manager class to create temporary file

### DIFF
--- a/gmt/tests/test_gmttempfile.py
+++ b/gmt/tests/test_gmttempfile.py
@@ -1,6 +1,5 @@
 """
-Test the behaviors of the Figure class
-Doesn't include the plotting commands, which have their own test files.
+Tests for GMTTempFile class
 """
 import os
 
@@ -14,7 +13,12 @@ def test_gmttempfile_prefix_suffix():
         assert os.path.basename(tmpfile.name).endswith('.txt')
     with GMTTempFile(prefix="user-prefix-") as tmpfile:
         assert os.path.basename(tmpfile.name).startswith('user-prefix-')
+        assert os.path.basename(tmpfile.name).endswith('.txt')
     with GMTTempFile(suffix='.log') as tmpfile:
+        assert os.path.basename(tmpfile.name).startswith('gmt-python-')
+        assert os.path.basename(tmpfile.name).endswith('.log')
+    with GMTTempFile(prefix="user-prefix-", suffix=".log") as tmpfile:
+        assert os.path.basename(tmpfile.name).startswith('user-prefix-')
         assert os.path.basename(tmpfile.name).endswith('.log')
 
 
@@ -25,3 +29,6 @@ def test_gmttempfile_read():
             ftmp.write('in.dat: N = 2\t<1/3>\t<2/4>\n')
         assert tmpfile.read() == 'in.dat: N = 2 <1/3> <2/4>\n'
         assert tmpfile.read(keep_tabs=True) == 'in.dat: N = 2\t<1/3>\t<2/4>\n'
+
+    # check if the temporary file is really deleted
+    assert not os.path.exists(tmpfile.name)

--- a/gmt/tests/test_gmttempfile.py
+++ b/gmt/tests/test_gmttempfile.py
@@ -1,0 +1,27 @@
+"""
+Test the behaviors of the Figure class
+Doesn't include the plotting commands, which have their own test files.
+"""
+import os
+
+from ..utils import GMTTempFile
+
+
+def test_gmttempfile_prefix_suffix():
+    "Make sure the prefix and suffix of temporary files are user specifiable"
+    with GMTTempFile() as tmpfile:
+        assert os.path.basename(tmpfile.name).startswith('gmt-python-')
+        assert os.path.basename(tmpfile.name).endswith('.txt')
+    with GMTTempFile(prefix="user-prefix-") as tmpfile:
+        assert os.path.basename(tmpfile.name).startswith('user-prefix-')
+    with GMTTempFile(suffix='.log') as tmpfile:
+        assert os.path.basename(tmpfile.name).endswith('.log')
+
+
+def test_gmttempfile_read():
+    "Make sure GMTTempFile.read() works"
+    with GMTTempFile() as tmpfile:
+        with open(tmpfile.name, "w") as ftmp:
+            ftmp.write('in.dat: N = 2\t<1/3>\t<2/4>\n')
+        assert tmpfile.read() == 'in.dat: N = 2 <1/3> <2/4>\n'
+        assert tmpfile.read(keep_tabs=True) == 'in.dat: N = 2\t<1/3>\t<2/4>\n'

--- a/gmt/utils.py
+++ b/gmt/utils.py
@@ -187,7 +187,18 @@ def is_nonstr_iter(value):
 
 class GMTTempFile():
     """
-    Context manager for temporaray file.
+    Context manager for creating closed temporary files.
+
+    This class does not return a file-like object. So, you can't do
+    ``for line in GMTTempFile()``, for example, or pass it to things that
+    need file objects.
+
+    Parameters
+    ----------
+    prefix : str
+        The temporary file name begins with the prefix.
+    suffix : str
+        The temporary file name ends with the suffix.
 
     Examples
     --------
@@ -219,13 +230,17 @@ class GMTTempFile():
 
     def read(self, keep_tabs=False):
         """
-        Read the entire contents of the file.
+        Read the entire contents of the file as a Unicode string.
 
         Parameters
         ----------
         keep_tabs : bool
             If False, replace the tabs that GMT uses with spaces.
 
+        Returns
+        -------
+        content : str
+            Content of the temporary file as a Unicode string.
         """
         with open(self.name) as tmpfile:
             content = tmpfile.read()
@@ -235,12 +250,17 @@ class GMTTempFile():
 
     def loadtxt(self, **kwargs):
         """
-        Load data from a text file, similar to numpy.loadtxt.
+        Load data from the temporary file using numpy.loadtxt.
 
         Parameters
         ----------
-        kwargs :
-            Additional keyword arguments passed to numpy.loadtxt.
+        kwargs : dict
+            Any keyword arguments that can be passed to numpy.loadtxt.
+
+        Returns
+        -------
+        ndarray
+            Data read from the text file.
 
         """
         return np.loadtxt(self.name, **kwargs)


### PR DESCRIPTION
First PR for #88.

## Changes proposed in this pull request

`GMTTempfile` context manager class to create temporary file.

Features:

- [x] create a closed file which GMT can write to
- [x] prefix is `gmt-python-` and user specifiable
- [x] suffix is `.txt` by default and user specifiable
- [x] delete the file when exiting
- [x] `read` method to open and return the entire contents of the file
- [x] `loadtxt` method, similar to `numpy.loadtxt`
- [x] replace the tabs that GMT uses with spaces to make it more Python friendly (with an options to keep them)
- [x] add more tests