### PR TITLE
rename OSX to macOS

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,7 +25,7 @@ Getting started
 ---------------
 
 1. Try an online demo at `try.gmtpython.xyz <http://try.gmtpython.xyz>`__
-2. :ref:`Install <install>` (tested and working on Linux and OSX)
+2. :ref:`Install <install>` (tested and working on Linux and macOS)
 3. Follow the :ref:`tutorials`.
 4. Take a look at the :ref:`api` for a list of modules that are already
    available.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -32,7 +32,7 @@ Dependencies
 GMT/Python requires the following libraries:
 
 * Current development version of GMT (6.0.0). ``conda`` packages for Linux and
-  OSX are available through
+  macOS are available through
   `conda-forge <https://github.com/conda-forge/gmt-feedstock/>`__.
 * numpy
 * pandas
@@ -70,7 +70,7 @@ And finally, install the rest of the dependencies::
 
 .. note::
 
-    **Currently, this only works on Linux and OSX.**
+    **Currently, this only works on Linux and macOS.**
 
     We don't have a GMT conda package for Windows
     (`we're working on it <https://github.com/conda-forge/gmt-feedstock>`__).

--- a/gmt/clib/utils.py
+++ b/gmt/clib/utils.py
@@ -175,7 +175,7 @@ def clib_extension(os_name=None):
 
     .. warning::
 
-        Currently only works for OSX and Linux.
+        Currently only works for macOS and Linux.
 
     Returns
     -------
@@ -195,7 +195,7 @@ def clib_extension(os_name=None):
     if os_name.startswith('linux'):
         lib_ext = 'so'
     elif os_name == 'darwin':
-        # Darwin is OSX
+        # Darwin is macOS
         lib_ext = 'dylib'
     else:
         raise GMTOSError(

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -67,7 +67,7 @@ def launch_external_viewer(fname):
     """
     Open a file in an external viewer program.
 
-    Uses the ``xdg-open`` command on Linux, the ``open`` command on OSX, and
+    Uses the ``xdg-open`` command on Linux, the ``open`` command on macOS, and
     the default web browser on other systems.
 
     Parameters
@@ -84,7 +84,7 @@ def launch_external_viewer(fname):
     # Fall back to the browser if can't recognize the operating system.
     if sys.platform.startswith('linux'):
         subprocess.run(['xdg-open', fname], **run_args)
-    elif sys.platform == 'darwin':  # Darwin is OSX
+    elif sys.platform == 'darwin':  # Darwin is macOS
         subprocess.run(['open', fname], **run_args)
     else:
         webbrowser.open_new_tab('file://{}'.format(fname))


### PR DESCRIPTION
`OSX` is renamed to `macOS` since 2016.