### PR TITLE
Use intersphinx to automatically link to external projects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
+    'sphinx.ext.intersphinx',
     'numpydoc',
     'nbsphinx',
 ]
@@ -79,6 +80,13 @@ html_context = {
     'doc_path': 'doc',
     'github_repo': 'GenericMappingTools/gmt-python',
     'github_version': 'master',
+}
+
+# intersphinx
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
 }
 
 # Load the custom CSS files (needs sphinx >= 1.6 for this to work)

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -308,8 +308,7 @@ file machinery.
 This allows us to write data to a memory location instead of a file without GMT
 knowing the difference.
 For input, we can use ``GMT_Open_VirtualFile`` and point it to the location in
-memory of the Python data, for example using `numpy.ndarray.ctypes
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ctypes.html>`__.
+memory of the Python data, for example using :attr:`numpy.ndarray.ctypes`.
 We can also translate the Python data into :py:mod:`ctypes` compatible types.
 The virtual file pointer can also be passed as the output option for the
 module, for example as ``-G`` or through redirection (``->``).

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -71,13 +71,13 @@ is equivalent to the following in modern mode::
     gmt end
 
 This is a great improvement: the code is smaller and more readable. It fits
-naturally with Python `context managers
-<https://docs.python.org/3/library/stdtypes.html#typecontextmanager>`__ and can
+naturally with Python :ref:`context managers <context-managers>` and can
 be used to embed PNG converted output into Jupyter notebooks when ``gmt end``
 is called.
 
 Read more about modern mode at the
 `Modernization wiki page <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
+
 
 
 GMT Python

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -94,10 +94,9 @@ the Postscript.
 This mode is perfect for the Python interface, which would have to handle
 generation of the Postscript file in the background anyway.
 
-We will wrap the GMT C API using the `ctypes
-<https://docs.python.org/3/library/ctypes.html>`__ module of the Python
+We will wrap the GMT C API using the :py:mod:`ctypes` module of the Python
 standard library.
-``ctypes`` grants access to C data types and foreign functions in DDLs and
+:py:mod:`ctypes` grants access to C data types and foreign functions in DDLs and
 shared libraries, making it possible to wrap these libraries with pure Python
 code.
 Not having compiled modules makes packaging and distribution of Python software
@@ -105,7 +104,7 @@ a lot easier.
 
 Wrappers for GMT data types and C functions will be implemented in a lower
 level wrapper library.
-These will be direct ``ctypes`` wrappers of the GMT module functions and any
+These will be direct :py:mod:`ctypes` wrappers of the GMT module functions and any
 other function that is needed on the Python side.
 The low-level functions will not handle any data type conversion or setting up
 of argument list.
@@ -260,8 +259,8 @@ them from the command-line help messages by passing a Python callback as the
 The low-level wrappers
 ----------------------
 
-The low-level wrapper functions will be bare-bones ``ctypes`` foreign functions
-from the ``libgmt.so`` shared library.
+The low-level wrapper functions will be bare-bones :py:mod:`ctypes` foreign
+functions from the ``libgmt.so`` shared library.
 The functions can be accessed from Python like so::
 
     import ctypes as ct
@@ -276,15 +275,15 @@ The functions can be accessed from Python like so::
 
 
 The tricky part is making sure the functions get the input types they need.
-``ctypes`` provides access to C data types and a way to specify the data type
-conversions that the function requires::
+:py:mod:`ctypes` provides access to C data types and a way to specify the data
+type conversions that the function requires::
 
     GMT_Call_Module.argstypes = [ct.c_void_p, ct.c_char_p, ct.c_int, ct.c_void_p]
 
 This is fine for standard data types like ``int``, ``char``, etc, but will need
 extra work for custom GMT ``struct``.
 These data types will need to be wrapped by Python classes that inherit from
-``ctypes.Structure``.
+:py:class:`ctypes.Structure`.
 
 The ``gmt.c_api`` module will expose these foreign functions (with output and
 input types specified) and GMT data types for the modules to use.
@@ -298,7 +297,7 @@ It has the following signature::
     int GMT_Call_Module (void *V_API, const char *module, int mode, void *args)
 
 The arguments ``module``, ``mode``, and ``args`` (the command-line argument
-list) are plain C types and can be generated easily using ``ctypes``.
+list) are plain C types and can be generated easily using :py:mod:`ctypes`.
 The Python module code will need to generate the ``args`` array from the
 given function arguments.
 The ``V_API`` argument is a "GMT Session" and is created through the
@@ -311,7 +310,7 @@ knowing the difference.
 For input, we can use ``GMT_Open_VirtualFile`` and point it to the location in
 memory of the Python data, for example using `numpy.ndarray.ctypes
 <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ctypes.html>`__.
-We can also translate the Python data into ``ctypes`` compatible types.
+We can also translate the Python data into :py:mod:`ctypes` compatible types.
 The virtual file pointer can also be passed as the output option for the
 module, for example as ``-G`` or through redirection (``->``).
 We can read the contents of the virtual file using ``GMT_Read_VirtualFile``.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -68,8 +68,7 @@ Project goals
 * Use the new `GMT modern mode
   <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__ for
   simplified execution and figure generation.
-* Interface with the GMT C API directly using
-  `ctypes <https://docs.python.org/3/library/ctypes.html>`__ (no system calls).
+* Interface with the GMT C API directly using :py:mod:`ctypes` (no system calls).
 * Integration with the `Jupyter notebook <http://jupyter.org/>`__ to display
   plots and maps inline.
 * Input and output using Python native containers: numpy ``ndarray`` or pandas

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -71,7 +71,7 @@ Project goals
 * Interface with the GMT C API directly using :py:mod:`ctypes` (no system calls).
 * Integration with the `Jupyter notebook <http://jupyter.org/>`__ to display
   plots and maps inline.
-* Input and output using Python native containers: numpy ``ndarray`` or pandas
+* Input and output using Python native containers: :class:`numpy.ndarray` or pandas
   ``DataFrame`` for data tables and `xarray <http://xarray.pydata.org>`__
   ``Dataset`` for netCDF grids.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -71,8 +71,8 @@ Project goals
 * Interface with the GMT C API directly using :py:mod:`ctypes` (no system calls).
 * Integration with the `Jupyter notebook <http://jupyter.org/>`__ to display
   plots and maps inline.
-* Input and output using Python native containers: :class:`numpy.ndarray` or pandas
-  ``DataFrame`` for data tables and `xarray <http://xarray.pydata.org>`__
+* Input and output using Python native containers: :class:`numpy.ndarray` or
+  :class:`pandas.DataFrame` for data tables and `xarray <http://xarray.pydata.org>`__
   ``Dataset`` for netCDF grids.
 
 

--- a/gmt/clib/__init__.py
+++ b/gmt/clib/__init__.py
@@ -3,8 +3,7 @@ Low-level wrapper for the GMT C API.
 
 The :class:`gmt.clib.LibGMT` class wraps the GMT C shared library (``libgmt``)
 with a pythonic interface.
-Access to the C library is done through
-`ctypes <https://docs.python.org/3/library/ctypes.html>`__.
+Access to the C library is done through :py:mod:`ctypes`.
 
 """
 from .core import LibGMT

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -270,8 +270,8 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         session : C void pointer (returned by ctypes as an integer)
             The active session object produced by
             :func:`gmt.clib.LibGMT.create_session`.
-        libgmt : ctypes.CDLL
-            The ``ctypes.CDLL`` instance for the libgmt shared library.
+        libgmt : :py:class:`ctypes.CDLL`
+            The :py:class:`ctypes.CDLL` instance for the libgmt shared library.
 
         """
         status = self._c_destroy_session(session)
@@ -652,7 +652,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
 
         Parameters
         ----------
-        dataset : ctypes.c_void_p
+        dataset : :py:class:`ctypes.c_void_p`
             The ctypes void pointer to a ``GMT_Dataset``. Create it with
             :meth:`~gmt.clib.LibGMT.create_data`.
         column : int
@@ -703,7 +703,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
 
         Parameters
         ----------
-        dataset : ctypes.c_void_p
+        dataset : :py:class:`ctypes.c_void_p`
             The ctypes void pointer to a ``GMT_Dataset``. Create it with
             :meth:`~gmt.clib.LibGMT.create_data`.
         matrix : numpy 2d-array
@@ -761,7 +761,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
             elements.
         output : str
             The output file name.
-        data : ctypes.c_void_p
+        data : :py:class:`ctypes.c_void_p`
             Pointer to the data container created by
             :meth:`~gmt.clib.LibGMT.create_data`.
 

--- a/gmt/clib/utils.py
+++ b/gmt/clib/utils.py
@@ -132,7 +132,7 @@ def _series_to_array(vector):
 
 def load_libgmt(libname='libgmt'):
     """
-    Find and load ``libgmt`` as a ctypes.CDLL.
+    Find and load ``libgmt`` as a :py:class:`ctypes.CDLL`.
 
     If not given the full path to the library, it must be in standard places or
     by discoverable by setting the environment variable ``LD_LIBRARY_PATH``.
@@ -145,7 +145,7 @@ def load_libgmt(libname='libgmt'):
 
     Returns
     -------
-    ctypes.CDLL object
+    :py:class:`ctypes.CDLL` object
         The loaded shared library.
 
     Raises
@@ -214,7 +214,7 @@ def check_libgmt(libgmt):
 
     Parameters
     ----------
-    libgmt : ctypes.CDLL
+    libgmt : :py:class:`ctypes.CDLL`
         A shared library loaded using ctypes.
 
     Raises


### PR DESCRIPTION
## Changes proposed in this pull request

Use intersphinx to automatically link to external projects (python, numpy and pandas). 

References:
1. http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
2. http://www.sphinx-doc.org/en/stable/domains.html#cross-referencing-python-objects
