### PR TITLE
Make sure GMTTempFile exists upon creation

### DIFF
--- a/gmt/tests/test_gmttempfile.py
+++ b/gmt/tests/test_gmttempfile.py
@@ -6,6 +6,22 @@ import os
 from ..utils import GMTTempFile
 
 
+def test_gmttempfile():
+    "Check that file is really created and deleted."
+    with GMTTempFile() as tmpfile:
+        assert os.path.exists(tmpfile.name)
+    # File should be deleted when leaving the with block
+    assert not os.path.exists(tmpfile.name)
+
+
+def test_gmttempfile_unique():
+    "Check that generating multiple files creates unique names"
+    with GMTTempFile() as tmp1:
+        with GMTTempFile() as tmp2:
+            with GMTTempFile() as tmp3:
+                assert tmp1.name != tmp2.name != tmp3.name
+
+
 def test_gmttempfile_prefix_suffix():
     "Make sure the prefix and suffix of temporary files are user specifiable"
     with GMTTempFile() as tmpfile:
@@ -29,6 +45,3 @@ def test_gmttempfile_read():
             ftmp.write('in.dat: N = 2\t<1/3>\t<2/4>\n')
         assert tmpfile.read() == 'in.dat: N = 2 <1/3> <2/4>\n'
         assert tmpfile.read(keep_tabs=True) == 'in.dat: N = 2\t<1/3>\t<2/4>\n'
-
-    # check if the temporary file is really deleted
-    assert not os.path.exists(tmpfile.name)

--- a/gmt/utils.py
+++ b/gmt/utils.py
@@ -218,7 +218,8 @@ class GMTTempFile():
     [0. 0. 0.] [1. 1. 1.] [2. 2. 2.]
     """
     def __init__(self, prefix="gmt-python-", suffix=".txt"):
-        with NamedTemporaryFile(prefix=prefix, suffix=suffix) as tmpfile:
+        args = dict(prefix=prefix, suffix=suffix, delete=False)
+        with NamedTemporaryFile(**args) as tmpfile:
             self.name = tmpfile.name
 
     def __enter__(self):


### PR DESCRIPTION
## Changes proposed in this pull request

Need to use the `delete=False` argument for `NamedTemporaryFile` to make
sure the file isn't deleted upon creation. Don't know if this would
cause problems in the future but better be safe. Add tests to make sure
things work and multiple files have unique names.

Extends #117 and relates to #88 


