### PR TITLE
Start the gmt.datasets package

### DIFF
--- a/doc/api/_generate_api.rst
+++ b/doc/api/_generate_api.rst
@@ -11,6 +11,7 @@ To include a new package/module, list it below and include it in api.index.rst
    :toctree: ./
 
    gmt
+   gmt.datasets
    gmt.exceptions
    gmt.clib
    gmt.helpers

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -4,6 +4,7 @@ API Reference
 =============
 
 .. include:: gmt.rst
+.. include:: gmt.datasets.rst
 .. include:: gmt.exceptions.rst
 .. include:: gmt.clib.rst
 .. include:: gmt.helpers.rst

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## A first map\n",
+    "## Our first map\n",
     "\n",
     "All figure generation in GMT/Python is handled by the `gmt.Figure` class. \n",
     "It has methods to add layers to your figure, like a basemap, coastlines, and data."
@@ -171,11 +171,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting point data\n",
+    "## Cartesian plots\n",
     "\n",
-    "We can use `gmt.Figure.plot` to plot data on our map.\n",
-    "\n",
-    "First, lets create some fake data to plot using numpy:"
+    "The `gmt.Figure` class has a `plot` method for displaying points and lines. Let's make a Cartesian x, y plot using some random data generated using numpy:"
    ]
   },
   {
@@ -196,100 +194,61 @@
     "# See the random number generator so we always \n",
     "# get the same numbers\n",
     "np.random.seed(42)\n",
-    "\n",
     "ndata = 100\n",
     "region = [150, 240, -10, 60]\n",
+    "# Create some fake distribution of points and a measured value\n",
+    "x = np.random.uniform(region[0], region[1], ndata)\n",
+    "y = np.random.uniform(region[2], region[3], ndata)\n",
+    "magnitude = np.random.uniform(1, 5, size=ndata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can plot the data using `Figure.plot` and the Cartesian projection `X`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = gmt.Figure()\n",
+    "# Create a 6x6 inch basemap using the data region\n",
+    "fig.basemap(region=region, projection='X6i', frame=True)\n",
+    "# Plot using triangles (i) of 0.3 cm\n",
+    "fig.plot(x, y, style='i0.3c', color='black')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can make the size of the markers follow the fake \"magnitude\" values by passing in the argument `sizes` to `Figure.plot`. We'll need to scale the magnitude so that it will reflect the size in centimeters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = gmt.Figure()\n",
+    "fig.basemap(region=region, projection='X6i', frame=True)\n",
+    "fig.plot(x, y, style='ic', color='black', sizes=magnitude/10)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting directly from a file\n",
     "\n",
-    "# Create fake epicenter, magnitude, and depth values\n",
-    "lon = np.random.uniform(region[0], region[1], ndata)\n",
-    "lat = np.random.uniform(region[2], region[3], ndata)\n",
-    "magnitude = np.random.uniform(1, 9, ndata)\n",
-    "depth = np.random.uniform(1, 600, ndata)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can plot the data using `Figure.plot` and passing the coordinate arrays as the x and y arguments:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = gmt.Figure()\n",
-    "# Plot using a global region ('g') and an Othographic projection ('G')\n",
-    "fig.coast(region='g', projection='G200/20/6i', frame='ag', land='grey', \n",
-    "          water='white')\n",
-    "# Plot using circles (c) of 0.1 cm\n",
-    "fig.plot(x=lon, y=lat, style='c0.1c', color='black')\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can make the size of the markers follow the magnitude values by passing in the argument `sizes` to `Figure.plot`. We'll need to scale the magnitude (the size is in centimeters) and use a power law to actually see all the different sizes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = gmt.Figure()\n",
-    "fig.coast(region='g', projection='G200/20/6i', frame='g', \n",
-    "          land='grey', water='white')\n",
-    "fig.plot(x=lon, y=lat, sizes=0.01*(1.7**magnitude), style='cc', \n",
-    "         color='black')\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also map the colors of the markers to the depths by passing an array to the `color` argument annd providing a colormap name (`cmap`). We can even use the new matplotlib colormap `\"viridis\"`. In order to highlight the depth range, we'll use the log10 of the depth instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "log_depth = np.log10(depth)\n",
-    "# We need to normalize the color because 'plot' can't \n",
-    "# autoscale the cmap to our data.\n",
-    "log_depth_norm = log_depth/log_depth.max()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = gmt.Figure()\n",
-    "fig.coast(region='g', projection='G200/20/6i', frame='g', \n",
-    "          land='grey', water='white')\n",
-    "fig.plot(x=lon, y=lat, sizes=0.01*(1.7**magnitude), style='cc', \n",
-    "         color=log_depth_norm, cmap='viridis')\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Plotting directly from a file\n",
-    "\n",
-    "Sometimes you'll have data in a file that you just want to plot without having to load it into Python. You can use the `data` argument to specify the file name instead `x` and `y`. GMT will take care of loading your data and plotting."
+    "Sometimes you'll have data in a file that you just want to plot without having to load it into Python. You can use the `data` argument of `Figure.plot` to specify the file name instead `x` and `y`. GMT will take care of loading your data and plotting."
    ]
   },
   {
@@ -300,14 +259,14 @@
    "source": [
     "# Save our fake data to a file.\n",
     "np.savetxt('first-steps-data.txt', \n",
-    "           np.transpose([lon, lat, magnitude, depth]))"
+    "           np.transpose([x, y, magnitude]))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the `columns` argument to control which columns we want to plot as x, y, color, and size, respectively. Adding `l` to a column will take the log10 of it and `sVALUE` will multiply it by that value. There are some limitations to this method on the kind of operations we can do with the data before plotting. For example, we can't use a power law for the magnitude."
+    "The `columns` argument controls which columns are used as x, y, color, and size, respectively. GMT allows some basic operations on the column values before plotting. For example, adding `sVALUE` to a column index will multiply it by that value before plotting."
    ]
   },
   {
@@ -317,11 +276,9 @@
    "outputs": [],
    "source": [
     "fig = gmt.Figure()\n",
-    "# Make a Mercator map this time.\n",
-    "fig.coast(region=region, projection='M6i', frame='afg',\n",
-    "          land='white', water='skyblue')\n",
-    "fig.plot(data='first-steps-data.txt', style='cc', cmap='inferno', \n",
-    "         columns=[0, 1, '3ls0.36', '2s0.05'])\n",
+    "fig.basemap(region=region, projection='X6i', frame=True)\n",
+    "fig.plot(data='first-steps-data.txt', style='cc', color='red', \n",
+    "         columns=[0, 1, '2s0.1'])\n",
     "fig.show()"
    ]
   },
@@ -329,9 +286,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Using sample data from GMT\n",
+    "## Making maps using sample data\n",
     "\n",
-    "GMT ships some sample data that can be accessed by passing `@data_file` as the `data` argument. For example, we can plot the earthquake epicenters from the `tut_quakes.ngdc` sample dataset:"
+    "GMT shines when plotting data on a map. We can use some **sample data** that is packaged with GMT to try this out. They can be accessed using special file names that begin with an `@` symbol, for example `@tut_quakes.ngdc`. You can supply these names as the `data` argument in `Figure.plot` and other plotting functions. If you don't have the files already, they are automatically downloaded by GMT and saved to a cache directory (usually `~/.gmt/cache`).\n",
+    "\n",
+    "The `gmt.datasets` package allows easy access to these data files as Python data types. For example, we can access the sample dataset of tsunami generating earthquakes around Japan (`@tut_quakes.ngdc`) as a `pandas.DataFrame` using the `datasets.load_japan_quakes` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gmt.datasets import load_japan_quakes\n",
+    "\n",
+    "quakes = load_japan_quakes()\n",
+    "quakes.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The functions returns to us the data in a `pandas.Dataframe` object that contains the date, hypocenter coordinates, and magnitude of the earthquakes.\n",
+    "\n",
+    "Let's make a local Mercator map of the epicenter coordinates. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quakes_region = [quakes.longitude.min(), quakes.longitude.max(),\n",
+    "                 quakes.latitude.min(), quakes.latitude.max()]\n",
+    "\n",
+    "fig = gmt.Figure()\n",
+    "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
+    "          land='black', water='skyblue')\n",
+    "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
+    "         style='c0.3c', color='white', pen='black')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we can map the size of the markers to the earthquake magnitude. Because the magnitude is on a logarithmic scale, it helps to show the differences by scaling the values using a power law."
    ]
   },
   {
@@ -341,11 +345,34 @@
    "outputs": [],
    "source": [
     "fig = gmt.Figure()\n",
-    "fig.coast(region=[130, 150, 35, 50], projection='M6i', \n",
-    "          frame='afg', shorelines=True, land='gray', \n",
-    "          water='lightblue')\n",
-    "fig.plot(data='@tut_quakes.ngdc', style='c0.3c', \n",
-    "         color='blue', columns=[4, 3])\n",
+    "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
+    "          land='black', water='skyblue')\n",
+    "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
+    "         sizes=0.02*(2**quakes.magnitude),\n",
+    "         style='cc', color='white', pen='black')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also map the colors of the markers to the depths by passing an array to the `color` argument and providing a colormap name (`cmap`). We can even use the new matplotlib colormap `\"viridis\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = gmt.Figure()\n",
+    "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
+    "          land='black', water='skyblue')\n",
+    "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
+    "         sizes=0.02*2**quakes.magnitude,\n",
+    "         color=quakes.depth_km/quakes.depth_km.max(),\n",
+    "         cmap='viridis', style='cc', pen='black')\n",
     "fig.show()"
    ]
   }
@@ -366,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/gmt/datasets/__init__.py
+++ b/gmt/datasets/__init__.py
@@ -1,0 +1,4 @@
+"""
+Load sample data included with GMT (downloaded from the GMT cache server).
+"""
+from .tutorial import load_japan_quakes

--- a/gmt/datasets/tutorial.py
+++ b/gmt/datasets/tutorial.py
@@ -1,8 +1,6 @@
 """
 Functions to load sample data from the GMT tutorials.
 """
-import os
-
 import pandas as pd
 
 from .. import which
@@ -27,7 +25,7 @@ def load_japan_quakes():
 
     """
     fname = which('@tut_quakes.ngdc', download='c')
-    data = pd.read_table(fname, header=1, sep='\s+')
+    data = pd.read_table(fname, header=1, sep=r'\s+')
     data.columns = ['year', 'month', 'day', 'latitude', 'longitude',
                     'depth_km', 'magnitude']
     return data

--- a/gmt/datasets/tutorial.py
+++ b/gmt/datasets/tutorial.py
@@ -1,0 +1,33 @@
+"""
+Functions to load sample data from the GMT tutorials.
+"""
+import os
+
+import pandas as pd
+
+from .. import which
+
+
+def load_japan_quakes():
+    """
+    Load a table of earthquakes around Japan as a pandas.Dataframe.
+
+    Data is from the NOAA NGDC database. This is the ``@tut_quakes.ngdc``
+    dataset used in the GMT tutorials.
+
+    The data are downloaded to a cache directory (usually ``~/.gmt/cache``) the
+    first time you invoke this function. Afterwards, it will load the data from
+    the cache. So you'll need an internet connection the first time around.
+
+    Returns
+    -------
+    data :  pandas.Dataframe
+        The data table. Columns are year, month, day, latitude, longitude,
+        depth (in km), and magnitude of the earthquakes.
+
+    """
+    fname = which('@tut_quakes.ngdc', download='c')
+    data = pd.read_table(fname, header=1, sep='\s+')
+    data.columns = ['year', 'month', 'day', 'latitude', 'longitude',
+                    'depth_km', 'magnitude']
+    return data

--- a/gmt/tests/test_datasets.py
+++ b/gmt/tests/test_datasets.py
@@ -1,0 +1,17 @@
+"""
+Test basic functionality for loading datasets.
+"""
+from ..datasets import load_japan_quakes
+
+
+def test_japan_quakes():
+    "Check that the dataset loads without errors"
+    data = load_japan_quakes()
+    assert data.shape == (115, 7)
+    summary = data.describe()
+    assert summary.loc['min', 'year'] == 1987
+    assert summary.loc['max', 'year'] == 1988
+    assert summary.loc['min', 'month'] == 1
+    assert summary.loc['max', 'month'] == 12
+    assert summary.loc['min', 'day'] == 1
+    assert summary.loc['max', 'day'] == 31


### PR DESCRIPTION
Start the gmt.datasets package with a function to load the `@tut_quakes.ngdc`
dataset from the GMT tutorials. Use it in the first-steps tutorial and include the 
package in the API reference.