### PR TITLE
Use base64 png instead of kml in worldwind preview

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,8 +29,6 @@ clean:
 	rm -rf api/generated
 	rm -rf .ipynb_checkpoints
 	rm -rf tutorials/first-steps-*
-	rm -rf tutorials/gmt-python-*.png
-	rm -rf tutorials/gmt-python-*.kml
 
 html: api
 	@echo
@@ -39,9 +37,6 @@ html: api
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-	@echo "Copying KML preview files to $(BUILDDIR)/html/tutorials."
-	cp tutorials/gmt-python-*.kml $(BUILDDIR)/html/tutorials
-	cp tutorials/gmt-python-*.png $(BUILDDIR)/html/tutorials
 
 api:
 	@echo

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig.savefig('first-steps-central-america.kml')"
+    "fig.savefig('first-steps-central-america.png')"
    ]
   },
   {
@@ -376,7 +376,7 @@
    "outputs": [],
    "source": [
     "fig = gmt.Figure()\n",
-    "fig.coast(region='JP', projection='M6i', frame=True, \n",
+    "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
     "         sizes=0.02*2**quakes.magnitude,\n",

--- a/doc/tutorials/first-steps.ipynb
+++ b/doc/tutorials/first-steps.ipynb
@@ -323,8 +323,15 @@
    "outputs": [],
    "source": [
     "quakes_region = [quakes.longitude.min() - 1, quakes.longitude.max() + 1,\n",
-    "                 quakes.latitude.min() - 1, quakes.latitude.max() + 1]\n",
-    "\n",
+    "                 quakes.latitude.min() - 1, quakes.latitude.max() + 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig = gmt.Figure()\n",
     "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
@@ -369,7 +376,7 @@
    "outputs": [],
    "source": [
     "fig = gmt.Figure()\n",
-    "fig.coast(region=quakes_region, projection='M6i', frame=True, \n",
+    "fig.coast(region='JP', projection='M6i', frame=True, \n",
     "          land='black', water='skyblue')\n",
     "fig.plot(x=quakes.longitude, y=quakes.latitude, \n",
     "         sizes=0.02*2**quakes.magnitude,\n",
@@ -382,7 +389,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's preview this map using the **interactive globe**. In this case, we don't need the frame or color in the oceans."
+    "Let's preview this map using the **interactive globe**. In this case, we don't need the frame or color in the oceans. We must also use a **Cartesian projection** (X) and degrees (d) for plot units so that the figure can be aligned with the globe."
    ]
   },
   {
@@ -397,13 +404,7 @@
     "         sizes=0.02*2**quakes.magnitude,\n",
     "         color=quakes.depth_km/quakes.depth_km.max(),\n",
     "         cmap='viridis', style='cc', pen='black')\n",
-    "# Need to use clean_kml=False so that the globe works\n",
-    "# when the notebook is converted to HTML for the documentation. \n",
-    "# Otherwise, the underlying KML file would be automatically deleted.\n",
-    "# Set the center of the view for the globe on our data\n",
-    "fig.show(method='globe', clean_kml=False, \n",
-    "         globe_view=(quakes.longitude.median(), quakes.latitude.median(), \n",
-    "                     1e7))"
+    "fig.show(method='globe')"
    ]
   }
  ],

--- a/gmt/helpers/__init__.py
+++ b/gmt/helpers/__init__.py
@@ -5,4 +5,4 @@ from .decorators import fmt_docstring, use_alias, kwargs_to_strings
 from .tempfile import GMTTempFile, unique_name
 from .utils import data_kind, dummy_context, build_arg_string, \
     is_nonstr_iter, launch_external_viewer
-from .worldwind import worldwind_show_kml
+from .worldwind import worldwind_show


### PR DESCRIPTION
Was using a KML preview loaded on WorldWind Web for the globe preview.
The problem was that the file needed to be in the same folder as the
notebook and couldn't be deleted after the preview was used.
Got around that by using a SurfaceImage layer instead of a KML layer.
The SurfaceImage takes a PNG image and region and displays it on the
globe.
The PNG can be inserted as a base64 encoded string using the Javascript
Image object.
This eliminates the need to keep the preview files around.

I capture the plot region by saving a KML preview and extracting the
bounding box from the KML file.
This is better than intercepting the 'region' argument in the
_preprocess method because it works for ISO country codes as well.
With the region, I can automatically set the view point.
