### PR TITLE
Use API to get fig region and make it a property

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -234,10 +234,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 docstring-min-length=-1
 
 # Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+function-name-hint=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
-function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+function-rgx=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,w,e,s,n,x,y,z

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -1066,7 +1066,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         >>> print(', '.join(['{:.2f}'.format(x) for x in wesn]))
         0.00, 10.00, -20.00, -10.00
 
-        Using ISO country codes for the regions (for example `'US.HI'` for
+        Using ISO country codes for the regions (for example ``'US.HI'`` for
         Hawaii):
 
         >>> fig = gmt.Figure()
@@ -1078,7 +1078,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         -164.71, -154.81, 18.91, 23.58
 
         The country codes can have an extra argument that rounds the region a
-        multiple of the argument (for example, `'US.HI+r5'` will round the
+        multiple of the argument (for example, ``'US.HI+r5'`` will round the
         region to multiples of 5):
 
         >>> fig = gmt.Figure()

--- a/gmt/tests/test_figure.py
+++ b/gmt/tests/test_figure.py
@@ -5,8 +5,43 @@ Doesn't include the plotting commands, which have their own test files.
 import os
 
 import pytest
+import numpy as np
+import numpy.testing as npt
 
 from .. import Figure
+
+
+def test_figure_region():
+    "Extract the plot region for the figure"
+    region = [0, 1, 2, 3]
+    fig = Figure()
+    fig.basemap(region=region, projection="X1id/1id", frame=True)
+    npt.assert_allclose(fig.region, np.array(region))
+
+
+def test_figure_region_multiple():
+    "Make sure the region argument is for the current figure"
+    region1 = [-10, 2, 0.355, 67]
+    fig1 = Figure()
+    fig1.basemap(region=region1, projection="X1id/1id", frame=True)
+
+    fig2 = Figure()
+    fig2.basemap(region='g', projection="X3id/3id", frame=True)
+
+    npt.assert_allclose(fig1.region, np.array(region1))
+    npt.assert_allclose(fig2.region, np.array([0.0, 360.0, -90.0, 90.0]))
+
+
+def test_figure_region_country_codes():
+    "Extract the plot region for the figure using country codes"
+    fig = Figure()
+    fig.basemap(region='JP', projection="M3i", frame=True)
+    npt.assert_allclose(fig.region,
+                        np.array([122.938515, 145.820877, 20.528774,
+                                  45.523136]))
+    fig = Figure()
+    fig.basemap(region='g', projection="X3id/3id", frame=True)
+    npt.assert_allclose(fig.region, np.array([0.0, 360.0, -90.0, 90.0]))
 
 
 def test_figure_savefig_exists():


### PR DESCRIPTION
Use the new LibGMT.extract_region API function to get the figure region.
Make it into a public property instead of a method of the Figure class.