### PR TITLE
Custom exception for invalid inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,9 +258,10 @@ necessary), but sometimes inputs must have a given set of properties or be from
 a predefined list of values.
 
 In these cases, an exceptions should be raised to signal the invalid
-inputs/outputs. We provide custom exceptions for this (see the API reference).
-In general, invalid inputs should raise `GMTInvalidInput`. The `gmt.clib`
-raises `GMTCLibError` when API functions return invalid status codes.
+inputs/outputs. Please avoid using `assert` statements. We provide custom
+exceptions for this (see the API reference). In general, invalid inputs should
+raise `GMTInvalidInput`. `gmt.clib` functions/methods should raise
+`GMTCLibError` when API functions return invalid status codes.
 
 
 ## Credit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,20 @@ passing.
 Don't forget to commit the baseline image as well.
 
 
+## Validating input and output values
+
+It's always a good idea to validate your input and output values to make sure
+that things fail in a predictable way. The validation shouldn't be too
+aggressive (for example, checking the data types of inputs is usually not
+necessary), but sometimes inputs must have a given set of properties or be from
+a predefined list of values.
+
+In these cases, an exceptions should be raised to signal the invalid
+inputs/outputs. We provide custom exceptions for this (see the API reference).
+In general, invalid inputs should raise `GMTInvalidInput`. The `gmt.clib`
+raises `GMTCLibError` when API functions return invalid status codes.
+
+
 ## Credit
 
 This guide was adapted from the [MetPy Contributing

--- a/gmt/exceptions.py
+++ b/gmt/exceptions.py
@@ -38,3 +38,10 @@ class GMTCLibNoSessionError(GMTCLibError):
     Tried to access GMT API without a currently open GMT session.
     """
     pass
+
+
+class GMTInvalidInput(GMTError):
+    """
+    Raised when the input of a function/method is invalid.
+    """
+    pass

--- a/gmt/figure.py
+++ b/gmt/figure.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from .clib import LibGMT
 from .base_plotting import BasePlotting
-from .exceptions import GMTError
+from .exceptions import GMTError, GMTInvalidInput
 from .helpers import build_arg_string, fmt_docstring, use_alias, \
     kwargs_to_strings, launch_external_viewer, unique_name, worldwind_show
 
@@ -196,11 +196,14 @@ class Figure(BasePlotting):
 
         prefix, ext = os.path.splitext(fname)
         ext = ext[1:]  # Remove the .
-        assert ext in fmts, "Unknown extension '.{}'".format(ext)
+        if ext not in fmts:
+            raise GMTInvalidInput("Unknown extension '.{}'".format(ext))
         fmt = fmts[ext]
         if transparent:
-            assert fmt == 'g', \
-                "Transparency unavailable for '{}', only for png.".format(ext)
+            if fmt != 'g':
+                raise GMTInvalidInput(
+                    "Transparency unavailable for '{}', only for png."
+                    .format(ext))
             fmt = fmt.upper()
         if anti_alias:
             kwargs['Qt'] = 2
@@ -254,7 +257,7 @@ class Figure(BasePlotting):
 
         """
         if method not in ['static', 'external', 'globe']:
-            raise GMTError("Invalid show method '{}'.".format(method))
+            raise GMTInvalidInput("Invalid show method '{}'.".format(method))
         if method == 'globe':
             png = self._preview(fmt='png', dpi=dpi, anti_alias=True,
                                 as_bytes=True, transparent=True)

--- a/gmt/helpers/decorators.py
+++ b/gmt/helpers/decorators.py
@@ -9,6 +9,7 @@ import textwrap
 import functools
 
 from .utils import is_nonstr_iter
+from ..exceptions import GMTInvalidInput
 
 
 GMT_DOCS = 'http://gmt.soest.hawaii.edu/doc/latest'
@@ -264,8 +265,10 @@ def kwargs_to_strings(convert_bools=True, **conversions):
     valid_conversions = ['sequence', 'sequence_comma']
 
     for arg, fmt in conversions.items():
-        assert fmt in valid_conversions, \
-            "Invalid conversion type '{}' for argument '{}'.".format(fmt, arg)
+        if fmt not in valid_conversions:
+            raise GMTInvalidInput(
+                "Invalid conversion type '{}' for argument '{}'."
+                .format(fmt, arg))
 
     separators = {'sequence': '/', 'sequence_comma': ','}
 

--- a/gmt/helpers/utils.py
+++ b/gmt/helpers/utils.py
@@ -7,7 +7,7 @@ import subprocess
 import webbrowser
 from contextlib import contextmanager
 
-from ..exceptions import GMTError
+from ..exceptions import GMTInvalidInput
 
 
 def data_kind(data, x, y):
@@ -48,27 +48,27 @@ def data_kind(data, x, y):
     >>> data_kind(data=None, x=None, y=None)
     Traceback (most recent call last):
         ...
-    gmt.exceptions.GMTError: No input data provided.
+    gmt.exceptions.GMTInvalidInput: No input data provided.
     >>> data_kind(data='data.txt', x=np.array([1, 2]), y=np.array([4, 5]))
     Traceback (most recent call last):
         ...
-    gmt.exceptions.GMTError: Too much data. Use either data or x and y.
+    gmt.exceptions.GMTInvalidInput: Too much data. Use either data or x and y.
     >>> data_kind(data='data.txt', x=np.array([1, 2]), y=None)
     Traceback (most recent call last):
         ...
-    gmt.exceptions.GMTError: Too much data. Use either data or x and y.
+    gmt.exceptions.GMTInvalidInput: Too much data. Use either data or x and y.
     >>> data_kind(data=None, x=np.array([1, 2]), y=None)
     Traceback (most recent call last):
         ...
-    gmt.exceptions.GMTError: Must provided both x and y.
+    gmt.exceptions.GMTInvalidInput: Must provided both x and y.
 
     """
     if data is None and x is None and y is None:
-        raise GMTError('No input data provided.')
+        raise GMTInvalidInput('No input data provided.')
     if data is not None and (x is not None or y is not None):
-        raise GMTError('Too much data. Use either data or x and y.')
+        raise GMTInvalidInput('Too much data. Use either data or x and y.')
     if data is None and (x is None or y is None):
-        raise GMTError('Must provided both x and y.')
+        raise GMTInvalidInput('Must provided both x and y.')
 
     if isinstance(data, str):
         kind = 'file'

--- a/gmt/modules.py
+++ b/gmt/modules.py
@@ -3,6 +3,7 @@ Non-plot GMT modules.
 """
 from .clib import LibGMT
 from .helpers import build_arg_string, fmt_docstring, GMTTempFile, use_alias
+from .exceptions import GMTInvalidInput
 
 
 @fmt_docstring
@@ -37,7 +38,8 @@ def info(fname, **kwargs):
         Report the min/max of the first (0'th) column to the nearest multiple
         of dz and output this as the string *-Tzmin/zmax/dz*.
     """
-    assert isinstance(fname, str), 'Only accepts file names.'
+    if not isinstance(fname, str):
+        raise GMTInvalidInput("'info' only accepts file names.")
 
     with GMTTempFile() as tmpfile:
         arg_str = ' '.join([fname, build_arg_string(kwargs),

--- a/gmt/tests/test_basemap.py
+++ b/gmt/tests/test_basemap.py
@@ -4,12 +4,13 @@ Tests fig.basemap.
 import pytest
 
 from .. import Figure
+from ..exceptions import GMTInvalidInput
 
 
 def test_basemap_required_args():
     "fig.basemap fails when not given required arguments"
     fig = Figure()
-    with pytest.raises(AssertionError):
+    with pytest.raises(GMTInvalidInput):
         fig.basemap(R='10/70/-3/8', J='X4i/3i')
 
 
@@ -25,7 +26,7 @@ def test_basemap_d():
 def test_basemap_d_raises():
     "Make sure the D raises an error when F not given."
     fig = Figure()
-    with pytest.raises(AssertionError):
+    with pytest.raises(GMTInvalidInput):
         fig.basemap(R='10/70/-300/800', J='X3i/5i', B='af', D='30/35/-200/500')
 
 

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -12,7 +12,7 @@ import pandas
 from ..clib.core import LibGMT
 from ..clib.utils import clib_extension, load_libgmt, check_libgmt
 from ..exceptions import GMTCLibError, GMTOSError, GMTCLibNotFoundError, \
-    GMTCLibNoSessionError
+    GMTCLibNoSessionError, GMTInvalidInput
 from ..helpers import GMTTempFile
 from .. import Figure
 
@@ -186,7 +186,7 @@ def test_parse_data_family_fails():
         'NOT_A_PROPER_FAMILY|ALSO_INVALID',
     ]
     for test_case in test_cases:
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             lib._parse_data_family(test_case)
 
 
@@ -239,7 +239,7 @@ def test_create_data_fails():
     "Test for failures on bad input"
     with LibGMT() as lib:
         # Passing in invalid mode
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             lib.create_data(
                 family='GMT_IS_DATASET',
                 geometry='GMT_IS_SURFACE',
@@ -249,7 +249,7 @@ def test_create_data_fails():
                 inc=[0.1, 0.2],
             )
         # Passing in invalid geometry
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             lib.create_data(
                 family='GMT_IS_GRID',
                 geometry='Not_a_valid_geometry',
@@ -300,7 +300,7 @@ def test_put_vector_invalid_dtype():
             dim=[2, 3, 1, 0],  # columns, rows, layers, dtype
         )
         data = np.array([37, 12, 556], dtype='complex128')
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             lib.put_vector(dataset, column=1, vector=data)
 
 
@@ -328,7 +328,7 @@ def test_put_vector_2d_fails():
             dim=[1, 6, 1, 0],  # columns, rows, layers, dtype
         )
         data = np.array([[37, 12, 556], [37, 12, 556]], dtype='int32')
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             lib.put_vector(dataset, column=0, vector=data)
 
 
@@ -420,7 +420,7 @@ def test_virtual_file_bad_direction():
         vfargs = ('GMT_IS_DATASET|GMT_VIA_MATRIX', 'GMT_IS_POINT',
                   'GMT_IS_GRID',  # The invalid direction argument
                   0)
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             with lib.open_virtual_file(*vfargs):
                 print("This should have failed")
 
@@ -468,7 +468,7 @@ def test_vectors_to_vfile_diff_size():
     x = np.arange(5)
     y = np.arange(6)
     with LibGMT() as lib:
-        with pytest.raises(GMTCLibError):
+        with pytest.raises(GMTInvalidInput):
             with lib.vectors_to_vfile(x, y):
                 print("This should have failed")
 

--- a/gmt/tests/test_figure.py
+++ b/gmt/tests/test_figure.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.testing as npt
 
 from .. import Figure
+from ..exceptions import GMTInvalidInput
 
 
 def test_figure_region():
@@ -65,7 +66,7 @@ def test_figure_savefig_transparent():
     prefix = 'test_figure_savefig_transparent'
     for fmt in 'pdf jpg bmp eps tif'.split():
         fname = '.'.join([prefix, fmt])
-        with pytest.raises(AssertionError):
+        with pytest.raises(GMTInvalidInput):
             fig.savefig(fname, transparent=True)
     # png should not raise an error
     fname = '.'.join([prefix, 'png'])
@@ -106,6 +107,11 @@ def test_figure_savefig():
     fig.savefig(fname)
     assert kwargs_saved[-1] == dict(prefix=prefix, fmt='e', crop=True, Qt=2,
                                     Qg=2)
+
+    fname = '.'.join([prefix, 'kml'])
+    fig.savefig(fname)
+    assert kwargs_saved[-1] == dict(prefix=prefix, fmt='g', crop=True, Qt=2,
+                                    Qg=2, W='+k')
 
 
 def test_figure_show():

--- a/gmt/tests/test_helpers.py
+++ b/gmt/tests/test_helpers.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from ..helpers import kwargs_to_strings, GMTTempFile, unique_name
+from ..exceptions import GMTInvalidInput
 
 
 def test_unique_name():
@@ -17,7 +18,7 @@ def test_unique_name():
 
 def test_kwargs_to_strings_fails():
     "Make sure it fails for invalid conversion types."
-    with pytest.raises(AssertionError):
+    with pytest.raises(GMTInvalidInput):
         kwargs_to_strings(bla="blablabla")
 
 

--- a/gmt/tests/test_info.py
+++ b/gmt/tests/test_info.py
@@ -3,7 +3,11 @@ Tests for gmtinfo
 """
 import os
 
+import pytest
+import numpy as np
+
 from .. import info
+from ..exceptions import GMTInvalidInput
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 POINTS_DATA = os.path.join(TEST_DATA_DIR, 'points.txt')
@@ -16,7 +20,6 @@ def test_info():
                        '<11.5309/61.7074> '
                        '<-2.9289/7.8648> '
                        '<0.1412/0.9338>\n').format(POINTS_DATA)
-
     assert output == expected_output
 
 
@@ -42,3 +45,11 @@ def test_info_t():
     "Make sure the T option works"
     output = info(fname=POINTS_DATA, T=0.1)
     assert output == '-T11.5/61.8/0.1\n'
+
+
+def test_info_fails():
+    "Make sure info raises an exception if not given a file name"
+    with pytest.raises(GMTInvalidInput):
+        info(fname=21)
+    with pytest.raises(GMTInvalidInput):
+        info(fname=np.arange(20))

--- a/gmt/tests/test_logo.py
+++ b/gmt/tests/test_logo.py
@@ -4,6 +4,7 @@ Tests for fig.logo
 import pytest
 
 from .. import Figure
+from ..exceptions import GMTInvalidInput
 
 
 @pytest.mark.mpl_image_compare
@@ -21,4 +22,12 @@ def test_logo_on_a_map():
     fig.coast(region=[-90, -70, 0, 20], projection='M6i', land='chocolate',
               frame=True)
     fig.logo(D='jTR+o0.1i/0.1i+w3i', F=True)
+    return fig
+
+
+def test_logo_fails():
+    "Make sure logo raises an exception when D is not given"
+    fig = Figure()
+    with pytest.raises(GMTInvalidInput):
+        fig.logo()
     return fig

--- a/gmt/tests/test_plot.py
+++ b/gmt/tests/test_plot.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 
 from .. import Figure
-from ..exceptions import GMTError
+from ..exceptions import GMTInvalidInput
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -39,17 +39,17 @@ def test_plot_red_circles(data, region):
 def test_plot_fail_no_data(data):
     "Plot should raise an exception if no data is given"
     fig = Figure()
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(region=region, projection='X4i', style='c0.2c', color='red',
                  frame='afg')
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(x=data[:, 0], region=region, projection='X4i', style='c0.2c',
                  color='red', frame='afg')
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(y=data[:, 0], region=region, projection='X4i', style='c0.2c',
                  color='red', frame='afg')
     # Should also fail if given too much data
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(x=data[:, 0], y=data[:, 1], data=data, region=region,
                  projection='X4i', style='c0.2c', color='red', frame='afg')
 
@@ -57,10 +57,10 @@ def test_plot_fail_no_data(data):
 def test_plot_fail_size_color(data):
     "Should raise an exception if array sizes and color are used with matrix"
     fig = Figure()
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(data=data, region=region, projection='X4i', style='c0.2c',
                  color=data[:, 2], frame='afg')
-    with pytest.raises(GMTError):
+    with pytest.raises(GMTInvalidInput):
         fig.plot(data=data, region=region, projection='X4i', style='cc',
                  sizes=data[:, 2], color='red', frame='afg')
 


### PR DESCRIPTION
Fixes #70

Defines the exception GMTInvalidInput and uses it throughout the
library.
Include a section in CONTRIBUTING.md about checking inputs and outputs and
which exceptions to raise.