### PR TITLE
Add function to load Earth relief data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,8 @@ dependencies:
     - gmt=6.0.0*
     - numpy
     - pandas
+    - xarray
+    - ipython
     - matplotlib
     - jupyter
     - pytest

--- a/gmt/datasets/__init__.py
+++ b/gmt/datasets/__init__.py
@@ -2,3 +2,4 @@
 Load sample data included with GMT (downloaded from the GMT cache server).
 """
 from .tutorial import load_japan_quakes
+from .earth_relief import load_earth_relief

--- a/gmt/datasets/earth_relief.py
+++ b/gmt/datasets/earth_relief.py
@@ -1,0 +1,40 @@
+"""
+Functions to download the Earth relief datasets from the GMT data sever.
+The grids are available in various resolutions.
+"""
+import xarray as xr
+
+from .. import which
+
+
+def load_earth_relief(resolution='60m'):
+    """
+    Load Earth relief grids (topography and bathimetry) in various resolutions.
+
+    The grids are downloaded to a user data directory (usually ``~/.gmt/``) the
+    first time you invoke this function. Afterwards, it will load the data from
+    the cache. So you'll need an internet connection the first time around.
+
+    These grids can also be accessed by passing in the file name
+    ``'@earth_relief_XXm'`` to any grid plotting/processing function.
+    Lower resolutions SRTM grids can be accessed by using '@earth_relief_XXs'
+    but they cannot be loaded using this function.
+
+    Parameters
+    ----------
+    resolution : str
+        The grid resolution. The prefix ``m`` stands for arc-minute. It can be
+        ``'60m'``, ``'30m'``, ``'10m'``, ``'05m'``, ``'02m'``, or ``'01m'``.
+
+    Returns
+    -------
+    grid :  xarray.DataArray
+        The Earth relief grid.
+
+    """
+    valid_resolutions = ['{:02d}m'.format(res)
+                         for res in [60, 30, 10, 5, 2, 1]]
+    if resolution not in valid_resolutions:
+        raise
+    fname = which('@earth_relief_{}'.format(resolution), download='u')
+    return fname

--- a/gmt/datasets/earth_relief.py
+++ b/gmt/datasets/earth_relief.py
@@ -5,20 +5,21 @@ The grids are available in various resolutions.
 import xarray as xr
 
 from .. import which
+from ..exceptions import GMTInvalidInput
 
 
 def load_earth_relief(resolution='60m'):
     """
-    Load Earth relief grids (topography and bathimetry) in various resolutions.
+    Load Earth relief grids (topography and bathymetry) in various resolutions.
 
     The grids are downloaded to a user data directory (usually ``~/.gmt/``) the
     first time you invoke this function. Afterwards, it will load the data from
     the cache. So you'll need an internet connection the first time around.
 
     These grids can also be accessed by passing in the file name
-    ``'@earth_relief_XXm'`` to any grid plotting/processing function.
-    Lower resolutions SRTM grids can be accessed by using '@earth_relief_XXs'
-    but they cannot be loaded using this function.
+    ``'@earth_relief_XXm'`` to any grid plotting/processing function. Higher
+    resolution SRTM grids can be accessed by using the ``'@earth_relief_XXs'``
+    special file names but they cannot be loaded using this function.
 
     Parameters
     ----------
@@ -29,12 +30,46 @@ def load_earth_relief(resolution='60m'):
     Returns
     -------
     grid :  xarray.DataArray
-        The Earth relief grid.
+        The Earth relief grid. Coordinates are latitude and longitude in
+        degrees. Relief is in meters.
 
     """
     valid_resolutions = ['{:02d}m'.format(res)
                          for res in [60, 30, 10, 5, 2, 1]]
     if resolution not in valid_resolutions:
-        raise
+        raise GMTInvalidInput("Invalid Earth relief resolution '{}'."
+                              .format(resolution))
     fname = which('@earth_relief_{}'.format(resolution), download='u')
-    return fname
+    grid = xr.open_dataarray(fname)
+    return grid
+
+
+def _shape_from_resolution(resolution):
+    """
+    Calculate the shape of the global Earth relief grid given a resolution.
+
+    Parameters
+    ----------
+    resolution : str
+        Same as the input for load_earth_relief
+
+    Returns
+    -------
+    shape : (nlat, nlon)
+        The calculated shape.
+
+    Examples
+    --------
+
+    >>> _shape_from_resolution('60m')
+    (181, 361)
+    >>> _shape_from_resolution('30m')
+    (361, 721)
+    >>> _shape_from_resolution('10m')
+    (1081, 2161)
+
+    """
+    minutes = int(resolution[:2])
+    nlat = 180*60//minutes + 1
+    nlon = 360*60//minutes + 1
+    return (nlat, nlon)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 gmt=6.0.0*
 numpy
 pandas
+xarray
 ipython
 # The following are required for development purposes
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ PLATFORMS = "Any"
 INSTALL_REQUIRES = [
     'numpy',
     'pandas',
+    'xarray',
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements the function `load_earth_relief` in `gmt.datasets` to load
the Earth relief grids distributed with GMT (the `@earth_relief_XXm` 
special file names). Uses `gmt.which` to download to the user directory 
and get the file name. The netCDF grid is loaded and returned as an 
xarray.DataArray. Only support the 60 to 1 arc-minute global grids. 
Higher resolution arc-second grids are served as tiles and are usually
cut to a specific area, so a `region` argument will be needed to load
these grids later, probably in conjunction with `gmt.grdcut`. 