### PR TITLE
Create LibGMT.grid_to_vfile for xarray support 

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -825,7 +825,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
     @contextmanager
     def vectors_to_vfile(self, *vectors):
         """
-        Store 1d arrays in a GMT virtual file to pass them to a module.
+        Store 1d arrays in a GMT virtual file to use as a module input.
 
         Context manager (use in a ``with`` block). Yields the virtual file name
         that you can pass as an argument to a GMT module call. Closes the
@@ -836,10 +836,11 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         :meth:`~gmt.clib.LibGMT.put_vector`, and
         :meth:`~gmt.clib.LibGMT.open_virtual_file`
 
-        The virtual file will contain the arrays as a GMT Dataset (via
-        vectors). If the arrays are C contiguous blocks of memory, they will be
-        passed without copying to GMT. If they are not (e.g., they are columns
-        of a 2D array), they will need to be copied to a contiguous block.
+        The virtual file will contain the arrays as ``GMT Vector`` structures.
+
+        If the arrays are C contiguous blocks of memory, they will be passed
+        without copying to GMT. If they are not (e.g., they are columns of a 2D
+        array), they will need to be copied to a contiguous block.
 
         Parameters
         ----------
@@ -902,13 +903,13 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
     @contextmanager
     def matrix_to_vfile(self, matrix):
         """
-        Store a 2d array in a GMT virtual file Dataset to pass it to a module.
+        Store a 2d array in a GMT virtual file to use as a module input.
 
         Context manager (use in a ``with`` block). Yields the virtual file name
         that you can pass as an argument to a GMT module call. Closes the
         virtual file upon exit of the ``with`` block.
 
-        The virtual file will contain the array as a GMT Dataset (via matrix).
+        The virtual file will contain the array as a ``GMT_MATRIX``.
 
         **Not meant for creating GMT Grids**. The grid requires more metadata
         than just the data matrix. This creates a Dataset (table).
@@ -982,7 +983,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
     @contextmanager
     def grid_to_vfile(self, grid):
         """
-        Store a grid in a GMT virtual file with a GMT_GRID container.
+        Store a grid in a GMT virtual file to use as a module input.
 
         Used to pass grid data into GMT modules. Grids must be
         ``xarray.DataArray`` instances.
@@ -991,7 +992,7 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         that you can pass as an argument to a GMT module call. Closes the
         virtual file upon exit of the ``with`` block.
 
-        The virtual file will contain the grid as a ``GMT_GRID`` (via matrix).
+        The virtual file will contain the grid as a ``GMT_MATRIX``.
 
         Use this instead of creating ``GMT_GRID`` and virtual files by hand
         with :meth:`~gmt.clib.LibGMT.create_data`,

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -1015,26 +1015,22 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         ...     with lib.grid_to_vfile(data) as vfile:
         ...         # Send the output to a file so that we can read it
         ...         with GMTTempFile() as ofile:
-        ...             args = '{} -L0 ->{}'.format(vfile, ofile.name)
+        ...             args = '{} -L0 -Cn ->{}'.format(vfile, ofile.name)
         ...             lib.call_module('grdinfo', args)
         ...             print(ofile.read().strip())
+        -180 180 -90 90 -8425 5551 1 1 361 181
+        >>> # The output is: w e s n z0 z1 dx dy n_columns n_rows
 
         """
-        region, inc, matrix = dataarray_to_matrix(grid)
-        nrows, ncolumns = grid.shape
+        matrix, region, inc = dataarray_to_matrix(grid)
         family = 'GMT_IS_GRID|GMT_VIA_MATRIX'
         geometry = 'GMT_IS_SURFACE'
-
         gmt_grid = self.create_data(family, geometry,
                                     mode='GMT_CONTAINER_ONLY',
-                                    dim=[ncolumns, nrows, 1, 0],
                                     ranges=region, inc=inc)
-
         self.put_matrix(gmt_grid, matrix)
-
         args = (family, geometry, 'GMT_IN|GMT_IS_REFERENCE', gmt_grid)
         with self.open_virtual_file(*args) as vfile:
-            # yield 'bla'
             yield vfile
 
     def extract_region(self):

--- a/gmt/clib/utils.py
+++ b/gmt/clib/utils.py
@@ -19,7 +19,7 @@ def dataarray_to_matrix(grid):
 
     >>> from gmt.datasets import load_earth_relief
     >>> grid = load_earth_relief(resolution='60m')
-    >>> region, inc, matrix = grid_to_region_inc_matrix(grid)
+    >>> matrix, region, inc = dataarray_to_matrix(grid)
     >>> print(region)
     [-180.0, 180.0, -90.0, 90.0]
     >>> print(inc)
@@ -34,26 +34,25 @@ def dataarray_to_matrix(grid):
         raise GMTInvalidInput(
             "Invalid number of grid dimensions '{}'. Must be 2."
             .format(len(grid.dims)))
-
     # Get the region and grid increment from grid coordinates.
-    # dims is ordered as row, column.
-    y, x = [grid.coords[dim].values for dim in grid.dims]
-    region = [x.min(), x.max(), y.min(), y.max()]
-    x_incs = x[1:] - x[0:-1]
-    x_inc = x_incs[0]
-    if not np.allclose(x_incs, x_inc):
+    east, north = [grid.coords[dim].values for dim in grid.dims]
+    region = [north.min(), north.max(), east.min(), east.max()]
+    north_incs = north[1:] - north[0:-1]
+    north_inc = north_incs[0]
+    if not np.allclose(north_incs, north_inc):
         raise GMTInvalidInput(
             "Grid appears to have irregular spacing in the '{}' dimension."
             .format(grid.dims[1]))
-    y_incs = y[1:] - y[0:-1]
-    y_inc = y_incs[0]
+    east_incs = east[1:] - east[0:-1]
+    east_inc = east_incs[0]
+    inc = [north_inc, east_inc]
 
-    matrix = grid.values
+    matrix = grid.values[:]
     # Array must be in C contiguous order to pass its memory pointer to GMT
     if not matrix.flags.c_contiguous:
         matrix = matrix.copy(order='C')
 
-    return region, [x_inc, y_inc], matrix
+    return matrix, region, inc
 
 
 def vectors_to_arrays(vectors):


### PR DESCRIPTION
## Changes proposed in this pull request

Implements a new context manager `LibGMT.grid_to_vfile` that takes
an `xarray.DataArray`, creates a `GMT_MATRIX` to store the data,
passes it along to a virtual file, and yields the virtual file name.

This is the main building block for supporting the `grd*` commands (#124).