### PR TITLE
Add xarray dependency to the install instructions

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -34,8 +34,9 @@ GMT/Python requires the following libraries:
 * Current development version of GMT (6.0.0). ``conda`` packages for Linux and
   macOS are available through
   `conda-forge <https://github.com/conda-forge/gmt-feedstock/>`__.
-* numpy
-* pandas
+* `numpy <http://www.numpy.org/>`__
+* `pandas <https://pandas.pydata.org/>`__
+* `xarray <http://xarray.pydata.org/>`__
 
 
 Installing GMT and other dependencies
@@ -71,7 +72,7 @@ Install the latest version of GMT 6::
 
 And finally, install the rest of the dependencies::
 
-    conda install numpy pandas
+    conda install numpy pandas xarray
 
 .. note::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ gmt=6.0.0*
 numpy
 pandas
 xarray
-ipython
 # The following are required for development purposes
+ipython
 matplotlib
 jupyter
 pytest


### PR DESCRIPTION
Forgot to add xarray to the install instructions.
While I'm at it, I added links to the numpy and pandas websites as well.
Thanks to Peyman Saemian for reporting this issue.