### PR TITLE
Using LibGMT in 'with' fails if GMT < 6.0.0

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -31,6 +31,11 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
     If creating GMT data structures to communicate data, put that code inside
     this context manager to reuse the same session.
 
+    Requires a minimum version of GMT (see ``LibGMT.required_version``). Will
+    check for the version when entering the ``with`` block. A
+    ``GMTVersionError`` exception will be raised if the minimum version
+    requirements aren't met.
+
     Parameters
     ----------
     libname : str
@@ -44,6 +49,8 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         couldn't access the functions).
     GMTCLibNoSessionError
         If you try to call a method outside of a 'with' block.
+    GMTVersionError
+        If the minimum required version of GMT is not found.
 
     Examples
     --------

--- a/gmt/exceptions.py
+++ b/gmt/exceptions.py
@@ -45,3 +45,10 @@ class GMTInvalidInput(GMTError):
     Raised when the input of a function/method is invalid.
     """
     pass
+
+
+class GMTVersionError(GMTError):
+    """
+    Raised when an incompatible version of GMT is being used.
+    """
+    pass


### PR DESCRIPTION
Uses the new LibGMT.info to check if GMT is at least 6.0.0. Raises a
GMTVersionError exception if it's not.

It would be great if we could check this upon instantiation but that
wouldn't work because `LibGMT.get_default` requires an active session.
So the only logical place to put this is in `LibGMT.__enter__` after the
session is created. The session is closed before the exception is
raised.

Fixes #171