### PR TITLE
Add function to print libgmt default parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ test:
 coverage:
 	# Run a tmp folder to make sure the tests are run on the installed version
 	mkdir -p $(TESTDIR)
+	cd $(TESTDIR); python -c "import gmt; gmt.print_libgmt_info()"
+	@echo ""
 	cd $(TESTDIR); pytest $(PYTEST_COV_ARGS) --cov=gmt $(PYTEST_ARGS) gmt
 	cp $(TESTDIR)/.coverage* .
 	rm -r $(TESTDIR)

--- a/gmt/__init__.py
+++ b/gmt/__init__.py
@@ -30,6 +30,29 @@ _begin()
 _atexit.register(_end)
 
 
+def print_libgmt_info():
+    """
+    Print information about the currently loaded GMT shared library.
+
+    Includes the GMT version, default values for parameters, the path to the
+    ``libgmt`` shared library, and GMT directories.
+    """
+    import shutil
+    from .clib import LibGMT
+
+    columns = shutil.get_terminal_size().columns
+    title = "Currently loaded libgmt"
+    left = (columns - len(title) - 2)//2
+    right = left + (columns - (2*left + len(title) + 2))
+    header = ' '.join(['='*left, title, '='*right])
+
+    with LibGMT() as lib:
+        lines = [header]
+        for key in sorted(lib.info):
+            lines.append('{}: {}'.format(key, lib.info[key]))
+    print('\n'.join(lines))
+
+
 def test(doctest=True, verbose=True, coverage=False, figures=True):
     """
     Run the test suite.
@@ -62,6 +85,9 @@ def test(doctest=True, verbose=True, coverage=False, figures=True):
 
     """
     import pytest
+
+    print_libgmt_info()
+
     args = []
     if verbose:
         args.append('-vv')


### PR DESCRIPTION
Function `print_libgmt_info` is defined as a utility in
`gmt.__init__.py` so that we can diagnose bug reports. It is used before
the tests are run to make sure the info is present and we know which
version of the library is being used for testing.

Fixes #170