### PR TITLE
Set libgmt path with GMT_LIBRARY_PATH from environ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
         # TWINE_PASSWORD to deploy to PyPI
         - secure: "md4fgPt9RC/sCoN5//5PcNHLUd9gWQGewV5hFpWW88MRTjxTng1Zfs8r7SqlF2AkEEepFfyzq0BEe9c3FMAnFbec3KmqdlQen4V8xDbLrcTlvkPlTrYGbAScUvdhhqojB//hMHoTD4KvxAv9CiUwFBO4hCMmj2buWHUbV9Ksu5WCW9mF/gkt/hIuYAU6Mbwt8PiYyMgUpzMHO1vruofcWRaVnvKwmBqHB0ae86D4/drpwn4CWjlM12WUnphT2bssiyPkw24FZtCN6kPVta6bLZKBxu0bZpw2vbXuUG+Yh19Q4mp8wNYT3XSHJf8Hl5LfujF48+cLWu+6rlCkdcelyVylhWLFc3rGOONAv4G8jWW2yNSz/bLQfJnMpd81fQEu5eySmFxB7mdB0uyKpvIG1jMJQ73LlYKakKLAPdYhMFyQAHoX9gvCE3S4QR95DBMi5gM/pZubOCcMLdjPHB5JKpJHSjxbOzyVwgmsUIEgd5Bi2vZvvYQXn1plk4xpQ3PhXc+/gi33bzY89mKcfOn0HJ2pD1vLqDXRCBsMCakoLZ0JB/6bacaz4FngbsGWuQ+I1cz20lJGL/MSi9bW1G7Uoidt3GXXWDmXrWt70vIXlLIxr8XV0Mu/rPbauGgWE+ZSYEfvdM5sP+FNF7vQ5de+Fkvzg5Z3tTfR+O1W+d7+vM4="
         - TWINE_USERNAME=Leonardo.Uieda
-        - LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
         - COVERAGE=false
         - BUILD_DOCS=false
         - DEPLOY_DOCS=false

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -121,13 +121,19 @@ Test your installation by running the following inside a Python interpreter::
 Finding the GMT shared library
 ------------------------------
 
-You might have to set the ``LD_LIBRARY_PATH``
-variable so that Python can find the GMT shared library ``libgmt``.
+Sometimes, GMT/Python will be unable to find the correct version of the GMT
+shared library. This can happen if you have multiple versions of GMT installed.
 
-If you installed GMT using conda, place the following in your ``~/.bashrc``
-file::
+You can tell GMT/Python exactly where to look for ``libgmt`` by setting the
+``GMT_LIBRARY_PATH`` environment variable. This should be set to the directory
+where ``libgmt.so`` (or ``.dylib``) is found. **Only use this as a last
+resort**. Setting the path in this way means that GMT/Python will not be able
+to easily find the correct ``libgmt`` when you're changing conda environments.
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/anaconda3/envs/gmt-python/lib
+If you installed GMT using conda using the instructions above and you're using
+Linux or Mac, place the following in your ``~/.bashrc`` file::
+
+    export GMT_LIBRARY_PATH=$HOME/anaconda3/envs/gmt-python/lib
 
 You should change ``$HOME/anaconda3`` to wherever you installed Anaconda (this
 is the default for Linux).

--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -36,11 +36,9 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
     ``GMTVersionError`` exception will be raised if the minimum version
     requirements aren't met.
 
-    Parameters
-    ----------
-    libname : str
-        The name of the GMT shared library **without the extension**. Can be a
-        full path to the library or just the library name.
+    By default, will look for the shared library in the directory specified by
+    the environment variable ``GMT_LIBRARY_PATH``. If the variable is not set,
+    will let ctypes try to find the library.
 
     Raises
     ------
@@ -105,10 +103,10 @@ class LibGMT():  # pylint: disable=too-many-instance-attributes
         'uint32': 'GMT_UINT',
     }
 
-    def __init__(self, libname='libgmt'):
+    def __init__(self):
         self._logfile = None
         self._session_id = None
-        self._libgmt = load_libgmt(libname)
+        self._libgmt = load_libgmt()
 
     @property
     def current_session(self):


### PR DESCRIPTION
`LibGMT` no longer takes a pathname as input. The library path is either
just the file name, or the directory is taken from the GMT_LIBRARY_PATH
environment variable. This allows users to direct the GMT/Python to
libgmt. It's useful to test against a local build of GMT trunk or
resolving path issues without resorting to LD_LIBRARY_PATH.

Replace section on LD_LIBRARY_PATH with GMT_LIBRARY_PATH in install
docs. Make it clear that this should be a last resort.

Fixes #172 and fixes #165