### PR TITLE
Remove work done in LibGMT.__init__

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -18,7 +18,7 @@ ignore-patterns=
 #init-hook=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=4
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,attribute-defined-outside-init
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/gmt/tests/test_clib.py
+++ b/gmt/tests/test_clib.py
@@ -46,14 +46,19 @@ def mock(lib, func, returns=None, mock_func=None):
 
         mock_func = mock_api_function
 
-    backup = getattr(lib._libgmt, func)
-    setattr(lib._libgmt, func, mock_func)
-    try:
-        yield
-    finally:
-        # Need to restore the original method to please pylint. Make sure it
-        # always happens by putting it in this finally block.
-        setattr(lib._libgmt, func, backup)
+    get_libgmt_func = lib.get_libgmt_func
+
+    def mock_get_libgmt_func(name, argtypes=None, restype=None):
+        """
+        Return our mock function.
+        """
+        if name == func:
+            return mock_func
+        return get_libgmt_func(name, argtypes, restype)
+
+    setattr(lib, 'get_libgmt_func', mock_get_libgmt_func)
+
+    yield
 
 
 def test_load_libgmt():


### PR DESCRIPTION
The shared library was being loaded in __init__, which is not a good
design pattern. Instead, now it's loaded the first time it gets used by
the new method `get_libgmt_func` that gets the ctypes function and sets
the return and argument types. This removes some redundancy from the
other methods (setting ctypes type conversions) and also removes the
usage of a private variable `_libgmt` from other methods. Now, only
methods that set a private variable need to know of it's existence.
The same applies to `_session_id` which is entirely encapsulated by
`current_session`.

*Please fill out the fields below and follow our [pull request guidelines](CONTRIBUTING.md#pull-requests).*

Fixes #

## Changes proposed in this pull request
