### PR TITLE
Remove nonexistent ci directory

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,6 +32,5 @@ exclude_paths:
 - "versioneer.py"
 - "gmt/_version.py"
 - "doc/**/*"
-- "ci/*"
 - "gmt/tests/baseline/*"
 - "gmt/tests/data/*"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst") as f:
 VERSION = versioneer.get_version()
 CMDCLASS = versioneer.get_cmdclass()
 
-PACKAGES = find_packages(exclude=["doc", "ci"])
+PACKAGES = find_packages(exclude=["doc"])
 SCRIPTS = []
 PACKAGE_DATA = {"gmt.tests": ["data/*", "baseline/*"]}
 


### PR DESCRIPTION
`ci` directory was removed in #188. This PR remove `ci` in `setup.py` and `.codeclimate.yml`.