### PR TITLE
Fix FutureWarning of pandas.DataFrame.as_matrix

### DIFF
--- a/gmt/clib/utils.py
+++ b/gmt/clib/utils.py
@@ -220,7 +220,7 @@ def _as_array(vector):
     --------
 
     >>> import pandas as pd
-    >>> x_series = pandas.Series(data=[1, 2, 3, 4])
+    >>> x_series = pd.Series(data=[1, 2, 3, 4])
     >>> x_array = _as_array(x_series)
     >>> type(x_array)
     <class 'numpy.ndarray'>
@@ -238,7 +238,7 @@ def _as_array(vector):
 
     """
     if isinstance(vector, pandas.Series):
-        return vector.as_matrix()
+        return vector.values
     return np.asarray(vector)
 
 


### PR DESCRIPTION
Travis reports some warnings:
```
gmt/clib/core.py::gmt.clib.core.LibGMT.vectors_to_vfile
  /home/travis/miniconda/envs/testing/lib/python3.6/site-packages/gmt/clib/utils.py:241: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
    return vector.as_matrix()
```

According to the official document, method ``.as_matrix`` is deprecated [since 0.23.0](https://pandas.pydata.org/pandas-docs/version/0.23.0/generated/pandas.DataFrame.as_matrix.html) and will be removed in a future version. ``.values`` can replace it.

``.as_matrix()`` and ``.values`` are the same and are coexistent since pandas 0.12 (see v0.12 document of [as_matrix](https://pandas.pydata.org/pandas-docs/version/0.12/generated/pandas.DataFrame.as_matrix.html) and [values](https://pandas.pydata.org/pandas-docs/version/0.12/generated/pandas.DataFrame.values.html)). So such change won't affect users with pandas>=0.12.
