### PR TITLE
Flush the printed messages from the C lib callback

### DIFF
--- a/gmt/clib/core.py
+++ b/gmt/clib/core.py
@@ -266,7 +266,8 @@ class LibGMT:  # pylint: disable=too-many-instance-attributes
             """
             message = message.decode().strip()
             self._log.append(message)
-            print(message, file=sys.stderr)
+            # flush to make sure the messages are printed even if we have a crash.
+            print(message, file=sys.stderr, flush=True)
             return 0
 
         # Need to store a copy of the function because ctypes doesn't and it will be


### PR DESCRIPTION
Flushing ensures that messages are printed even if the C lib call causes
a crash. This way we can get debug messages always.