### PR TITLE
Don't install black on TravisCI automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet -c conda-forge/label/dev gmt=6.0.0a*
+    - conda install --yes --quiet -c conda-forge/label/dev gmt=6.0.0a* python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi
@@ -70,7 +70,9 @@ install:
 
 script:
     # Check code for style and lint for code quality
+    # Black is Python 3.6 only so it can't be in the requirements file.
     - if [ "$CHECK" == "true" ]; then
+        conda install --yes --quiet --channel conda-forge black python=$PYTHON;
         make check;
       fi
     # Run the test suite. Make pytest report any captured output on stdout or stderr.

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ before_install:
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet -c conda-forge/label/dev gmt=6.0.0a* python=$PYTHON
+    - conda install --yes --quiet -c conda-forge/label/dev gmt=6.0.0a*
+    # Make sure that Python is still the correct version
+    - python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '$PYTHON'.split('.'))"
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ pytest
 pytest-cov
 pytest-mpl
 coverage
-black
 pylint
 sphinx
 sphinx_rtd_theme
@@ -20,3 +19,5 @@ numpydoc
 twine
 # The following are installed for checking possible conflicts
 basemap
+# Black is not included because it requires Python 3.6
+#black


### PR DESCRIPTION
Black is Python 3.6 only so installing it through the requirements.txt
file was causing a silent upgrade of Python.

Will help with the problems in #212 