### PR TITLE
Pass in NULL pointer to GMT_Get_Enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - source continuous-integration/travis/setup-miniconda.sh
     - conda config --append channels conda-forge/label/dev
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet gmt="6.*" python=$PYTHON
+    - conda install --yes --quiet gmt>=6 python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
     - conda config --append channels conda-forge/label/dev
     - conda config --remove channels defaults
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet gmt=6.0.0a* python=$PYTHON
+    - conda install --yes --quiet gmt=6.* python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - source continuous-integration/travis/setup-miniconda.sh
     - conda config --append channels conda-forge/label/dev
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet gmt>=6 python=$PYTHON
+    - conda install --yes --quiet "gmt>=6" python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - source continuous-integration/travis/setup-miniconda.sh
     - conda config --append channels conda-forge/label/dev
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet gmt=6.* python=$PYTHON
+    - conda install --yes --quiet gmt="6.*" python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,10 @@ before_install:
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
+    - conda config --append channels conda-forge/label/dev
+    - conda config --remove channels defaults
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet -c conda-forge -c conda-forge/label/dev gmt=6.0.0a*
+    - conda install --yes --quiet gmt=6.0.0a*
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - source continuous-integration/travis/setup-miniconda.sh
     - conda config --append channels conda-forge/label/dev
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet "gmt>=6" python=$PYTHON
+    - conda install --yes --quiet "gmt=6.0.*" python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
     # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet -c conda-forge/label/dev gmt=6.0.0a*
+    - conda install --yes --quiet -c conda-forge -c conda-forge/label/dev gmt=6.0.0a*
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ before_install:
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
     - conda config --append channels conda-forge/label/dev
-    - conda config --remove channels defaults
     # Install GMT from the dev channel to get development builds of GMT 6
     - conda install --yes --quiet gmt=6.* python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
         - DEPLOY_DOCS=false
         - DEPLOY_PYPI=false
         - CONDA_REQUIREMENTS="requirements.txt"
+        # Get GMT6 from the development channel
+        - CONDA_EXTRA_CHANNEL=conda-forge/label/dev
 
 matrix:
     # Build under the following configurations
@@ -55,9 +57,6 @@ before_install:
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
-    - conda config --append channels conda-forge/label/dev
-    # Install GMT from the dev channel to get development builds of GMT 6
-    - conda install --yes --quiet "gmt=6.0.*" python=$PYTHON
     - if [ "$COVERAGE" == "true" ]; then
         pip install codecov codacy-coverage codeclimate-test-reporter;
       fi

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: gmt-python
 channels:
     - conda-forge
     - conda-forge/label/dev
-    - defaults
 dependencies:
     - python=3.6
     - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# GMT isn't included because it needs to be downloaded from a separate channel
+gmt=6.0.0*
 numpy
 pandas
 xarray


### PR DESCRIPTION
Updated `gmt.clib.Session.__getitem__` to reflect update GMT 6.0.0 API for for `GMT_Get_Enum`. 
This update breaks compatability with trunk revisions prior to r20437. However,
a rudimentary check is done to try to indicate to the user. It can be removed
once GMT 6.0.0 is released.

Additionally, session handling has been added to `__getitem__` to use the
session pointer if there is an open session. 

Warning added to API documentation

Fixes #222 
