### PR TITLE
Explicitly install netCDF4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - numpy
     - pandas
     - xarray
+    - netCDF4
     - packaging
     - ipython
     - matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ gmt=6.0.0*
 numpy
 pandas
 xarray
+netCDF4
 packaging
 # The following are required for development purposes
 ipython

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ CLASSIFIERS = [
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"
-INSTALL_REQUIRES = ["numpy", "pandas", "xarray", "packaging"]
+INSTALL_REQUIRES = ["numpy", "pandas", "xarray", "netCDF4", "packaging"]
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
**Description of proposed changes**

conda-forge/xarray-feedstock [drops optional dependencies](https://github.com/conda-forge/xarray-feedstock/pull/37) several days ago. Thus we need install netCDF4 explicitly.

Fixes #238

**Reminders**

- [X] Run `make format` and `make check` to make sure the code follows the style guide.
- [X] Add tests for new features or tests that would have caught the bug that you're fixing.
- [X] Add new public functions/methods/classes to `doc/api/index.rst`.
- [X] Write detailed docstrings for all functions/methods.
- [X] If adding new functionality, add an example to docstrings or tutorials.
