### PR TITLE
Remove unnecessary pass statement reported by pylint 2.2.x

### DIFF
--- a/gmt/exceptions.py
+++ b/gmt/exceptions.py
@@ -10,15 +10,11 @@ class GMTError(Exception):
     Base class for all GMT related errors.
     """
 
-    pass
-
 
 class GMTOSError(GMTError):
     """
     Unsupported operating system.
     """
-
-    pass
 
 
 class GMTCLibError(GMTError):
@@ -26,15 +22,11 @@ class GMTCLibError(GMTError):
     Error encountered when running a function from the GMT shared library.
     """
 
-    pass
-
 
 class GMTCLibNotFoundError(GMTCLibError):
     """
     Could not find the GMT shared library.
     """
-
-    pass
 
 
 class GMTCLibNoSessionError(GMTCLibError):
@@ -42,20 +34,14 @@ class GMTCLibNoSessionError(GMTCLibError):
     Tried to access GMT API without a currently open GMT session.
     """
 
-    pass
-
 
 class GMTInvalidInput(GMTError):
     """
     Raised when the input of a function/method is invalid.
     """
 
-    pass
-
 
 class GMTVersionError(GMTError):
     """
     Raised when an incompatible version of GMT is being used.
     """
-
-    pass

--- a/gmt/sphinxext/gmtplot.py
+++ b/gmt/sphinxext/gmtplot.py
@@ -74,8 +74,6 @@ class GMTPlotNode(nodes.General, nodes.Element):
     Sphinx node for a GMT plot.
     """
 
-    pass
-
 
 class GMTPlotDirective(Directive):
     """


### PR DESCRIPTION
**Description of proposed changes**

Recent pylint release adds a new check for unnecessary pass statement, which makes our travis build failing. See https://github.com/PyCQA/pylint/issues/2208 for details. This PR removes all the unnecessary pass statement reported by pylint.