### PR TITLE
Remove gmt from requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ env:
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
-        # Get GMT6 from the development channel
+        # Get GMT6 from conda-forge development channel
+        - CONDA_INSTALL_EXTRA="gmt=6.0.0*"
         - CONDA_EXTRA_CHANNEL=conda-forge/label/dev
         # These variables control which actions are performed in a build
         - TEST=false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-gmt=6.0.0*
 numpy
 pandas
 xarray


### PR DESCRIPTION
**Description of proposed changes**

Strictly speaking, gmt-python doesn't dependent on conda-forge's gmt, thus I propose to remove the gmt dependency from requirements.txt. 

Also, such change makes it easy to test gmt-python with latest gmt master branch.