### PR TITLE
Fix small typo in disclaimer message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ GMT/Python
 Disclaimer
 ----------
 
-🚨 **This package in early stages of design and implementation.** 🚨
+🚨 **This package is in the early stages of design and implementation.** 🚨
 
 All functions/classes/interfaces are subject to change as we experiment with new design
 ideas and implement new features. **This is NOT a finished product.**


### PR DESCRIPTION
**Description of proposed changes**

Just a fix of a small typo in the disclaimer message which appears on GitHub and is included in [`doc/index.rst`](https://github.com/GenericMappingTools/gmt-python/blob/master/doc/index.rst).

*Please let me know if I should be proposing changes via an Issue instead and I can remove this... still learning how to contribute. Thanks!*