### PR TITLE
Remove the links to the binder example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@ GMT/Python
 
     A Python interface for the Generic Mapping Tools
 
-`Documentation <https://www.gmtpython.xyz>`__ |
-`Online Demo <http://try.gmtpython.xyz>`__ |
+`Documentation (development version) <https://www.gmtpython.xyz>`__ |
 `Contact <https://gitter.im/GenericMappingTools/gmt-python>`__
 
 .. image:: http://img.shields.io/pypi/v/gmt-python.svg?style=flat-square
@@ -144,4 +143,3 @@ License
 GMT/Python is free software: you can redistribute it and/or modify it under the terms of
 the **BSD 3-clause License**. A copy of this license is provided in
 `LICENSE.txt <https://github.com/GenericMappingTools/gmt-python/blob/master/LICENSE.txt>`__.
-.

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -41,7 +41,7 @@
 
     {% if menu_links %}
         <p class="caption">
-            <span class="caption-text">External links</span>
+            <span class="caption-text">Getting help and contributing</span>
         </p>
         <ul>
             {% for text, link in menu_links %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,12 +3,8 @@ import sys
 import os
 import datetime
 import sphinx_rtd_theme
-
-# Sphinx needs to be able to import the package to use autodoc and get the
-# version number
-sys.path.append(os.path.pardir)
-
 from gmt import __version__, __commit__
+
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -79,26 +75,25 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {}
 html_context = {
     "menu_links": [
-        ('<i class="fa fa-play fa-fw"></i> Try it online!', "http://try.gmtpython.xyz"),
-        (
-            '<i class="fa fa-github fa-fw"></i> Source Code',
-            "https://github.com/GenericMappingTools/gmt-python",
-        ),
         (
             '<i class="fa fa-users fa-fw"></i> Contributing',
             "https://github.com/GenericMappingTools/gmt-python/blob/master/CONTRIBUTING.md",
         ),
         (
-            '<i class="fa fa-book fa-fw"></i> Code of Conduct',
+            '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
             "https://github.com/GenericMappingTools/gmt-python/blob/master/CODE_OF_CONDUCT.md",
         ),
         (
-            '<i class="fa fa-gavel fa-fw"></i> License',
+            '<i class="fa fa-book fa-fw"></i> License',
             "https://github.com/GenericMappingTools/gmt-python/blob/master/LICENSE.txt",
         ),
         (
             '<i class="fa fa-comment fa-fw"></i> Contact',
             "https://gitter.im/GenericMappingTools/gmt-python",
+        ),
+        (
+            '<i class="fa fa-github fa-fw"></i> Source Code',
+            "https://github.com/GenericMappingTools/gmt-python",
         ),
     ],
     # Custom variables to enable "Improve this page"" and "Download notebook"
@@ -107,6 +102,7 @@ html_context = {
     "github_repo": "GenericMappingTools/gmt-python",
     "github_version": "master",
 }
+
 
 # Load the custom CSS files (needs sphinx >= 1.6 for this to work)
 def setup(app):


### PR DESCRIPTION
It's broken and after #261 we won't have the conda-forge GMT builds
anymore. That makes it tricky to offer the demo. It served its purpose
and we can revive it after GMT 6 is out.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
